### PR TITLE
feat(nixos): 新增 Beelink 主机配置

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -1,0 +1,14 @@
+{...}: {
+  imports = [
+    ./hardware.nix
+  ];
+
+  services' = {
+    networkmanager.enable = true;
+    openssh.enable = true;
+    vnstat.enable = true;
+    zram.enable = true;
+  };
+
+  security'.firewall.enable = true;
+}

--- a/hosts/nixos/beelink/disko.nix
+++ b/hosts/nixos/beelink/disko.nix
@@ -1,0 +1,112 @@
+{...}: {
+  disko.devices = {
+    nodev."/" = {
+      fsType = "tmpfs";
+      mountOptions = [
+        "mode=755"
+        "nodev"
+        "nosuid"
+        "relatime"
+        "size=4G"
+      ];
+    };
+
+    disk.main = {
+      type = "disk";
+      device = "/dev/disk/by-id/nvme-CT1000P3PSSD8_24364AD5D8E0";
+
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            priority = 1;
+            size = "1G";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              extraArgs = [
+                "-n"
+                "BOOT"
+              ];
+              mountOptions = ["umask=0077"];
+            };
+          };
+
+          luks = {
+            priority = 2;
+            size = "100%";
+            type = "8309";
+            content = {
+              type = "luks";
+              name = "crypted";
+              askPassword = true;
+              initrdUnlock = true;
+              settings = {
+                allowDiscards = true;
+                bypassWorkqueues = true;
+                crypttabExtraOpts = [
+                  "same-cpu-crypt"
+                  "submit-from-crypt-cpus"
+                  "token-timeout=10"
+                ];
+              };
+              extraFormatArgs = [
+                "--type"
+                "luks2"
+                "--pbkdf"
+                "argon2id"
+              ];
+
+              content = {
+                type = "btrfs";
+                extraArgs = [
+                  "-f"
+                  "--csum"
+                  "xxhash64"
+                  "--label"
+                  "NixOS"
+                ];
+                mountpoint = "/btr_pool";
+                mountOptions = [
+                  "noatime"
+                  "subvolid=5"
+                ];
+
+                subvolumes = {
+                  "@nix" = {
+                    mountpoint = "/nix";
+                    mountOptions = [
+                      "compress-force=zstd:1"
+                      "discard=async"
+                      "noatime"
+                    ];
+                  };
+
+                  "@persistent" = {
+                    mountpoint = "/persistent";
+                    mountOptions = [
+                      "compress-force=zstd:1"
+                      "discard=async"
+                      "noatime"
+                    ];
+                  };
+
+                  "@snapshots" = {
+                    mountpoint = "/snapshots";
+                    mountOptions = [
+                      "compress-force=zstd:1"
+                      "discard=async"
+                      "noatime"
+                    ];
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/hosts/nixos/beelink/hardware.nix
+++ b/hosts/nixos/beelink/hardware.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}: {
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  boot.initrd.availableKernelModules = ["nvme" "xhci_pci" "thunderbolt" "usbhid" "usb_storage" "sd_mod"];
+  boot.initrd.kernelModules = [];
+  boot.kernelModules = ["kvm-amd"];
+  boot.extraModulePackages = [];
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  boot.loader = {
+    systemd-boot.enable = true;
+    efi.canTouchEfiVariables = true;
+  };
+
+  hardware'.disko = {
+    enable = true;
+    device = "/dev/disk/by-id/nvme-CT1000P3PSSD8_24364AD5D8E0";
+    espSize = "1G";
+    luks.enable = true;
+  };
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+}


### PR DESCRIPTION
## 概要

- 新增 headless 的 Beelink NixOS 主机配置
- 新增独立的 Disko 布局，使用 LUKS2 与 Btrfs 子卷
- 使用 zram swap，不设磁盘 swap 子卷
- 启用 NetworkManager、OpenSSH、vnStat 和防火墙
