### PR TITLE
feat(nixos): Beelink 改用 CachyOS latest 内核

### DIFF
--- a/hosts/nixos/beelink/hardware.nix
+++ b/hosts/nixos/beelink/hardware.nix
@@ -14,7 +14,9 @@
   boot.initrd.kernelModules = [];
   boot.kernelModules = ["kvm-amd"];
   boot.extraModulePackages = [];
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest-lto-x86_64-v3;
+
+  nixpkgs.overlays = [inputs.nix-cachyos-kernel.overlays.pinned];
 
   boot.loader = {
     systemd-boot.enable = true;


### PR DESCRIPTION
将 Beelink 切换到 CachyOS latest 的 LTO x86_64-v3 内核，并使用固定的 overlay 以便构建与缓存兼容。
