### PR TITLE
perf(nixos): 避免强制 Btrfs 压缩

### DIFF
--- a/docs/NixOS 安装指南.md
+++ b/docs/NixOS 安装指南.md
@@ -90,7 +90,7 @@
                   "@nix" = {
                     mountpoint = "/nix";
                     mountOptions = [
-                      "compress-force=zstd:1"
+                      "compress=zstd:1"
                       "discard=async"
                       "noatime"
                     ];
@@ -99,7 +99,7 @@
                   "@persistent" = {
                     mountpoint = "/persistent";
                     mountOptions = [
-                      "compress-force=zstd:1"
+                      "compress=zstd:1"
                       "discard=async"
                       "noatime"
                     ];
@@ -108,7 +108,7 @@
                   "@snapshots" = {
                     mountpoint = "/snapshots";
                     mountOptions = [
-                      "compress-force=zstd:1"
+                      "compress=zstd:1"
                       "discard=async"
                       "noatime"
                     ];

--- a/modules/nixos/base/hardware/disko.nix
+++ b/modules/nixos/base/hardware/disko.nix
@@ -11,7 +11,7 @@
       "@nix" = {
         mountpoint = "/nix";
         mountOptions = [
-          "compress-force=zstd:1"
+          "compress=zstd:1"
           "discard=async"
           "noatime"
         ];
@@ -20,7 +20,7 @@
       "@persistent" = {
         mountpoint = "/persistent";
         mountOptions = [
-          "compress-force=zstd:1"
+          "compress=zstd:1"
           "discard=async"
           "noatime"
         ];
@@ -29,7 +29,7 @@
       "@snapshots" = {
         mountpoint = "/snapshots";
         mountOptions = [
-          "compress-force=zstd:1"
+          "compress=zstd:1"
           "discard=async"
           "noatime"
         ];


### PR DESCRIPTION
对 Nix、persistent 和 snapshots 子卷改用常规 zstd 压缩，并同步更新安装指南。
