### PR TITLE
fix(nix): 将 trusted users 限制为已配置账户

### DIFF
--- a/modules/nixos/base/system/nix.nix
+++ b/modules/nixos/base/system/nix.nix
@@ -10,7 +10,7 @@
     settings = {
       substituters = lib.mkAfter ["https://attic.xuyh0120.win/lantian"];
       trusted-public-keys = lib.mkAfter ["lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc="];
-      trusted-users = ["@wheel"];
+      trusted-users = [myvars.username];
     };
   };
 


### PR DESCRIPTION
将 Nix 的 trusted users 从整个 wheel 组收窄为仅限已配置的账户。
