### PR TITLE
feat(nixos): 新增 PostgreSQL 服务模块

### DIFF
--- a/modules/nixos/base/services/postgresql.nix
+++ b/modules/nixos/base/services/postgresql.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  cfg = config.services'.postgresql;
+  user = config.core'.userName;
+in {
+  options.services'.postgresql = {
+    enable = lib.mkEnableOption "Enable PostgreSQL service";
+    openFirewall = lib.mkEnableOption "Open firewall port for PostgreSQL";
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.postgresql = {
+      enable = true;
+      package = pkgs.postgresql_18;
+      enableJIT = true;
+      enableTCPIP = cfg.openFirewall;
+
+      settings = {
+        port = 5432;
+        max_connections = 100;
+        log_connections = true;
+        log_statement = "ddl";
+        logging_collector = true;
+        log_disconnections = true;
+        log_destination = lib.mkForce "syslog";
+        shared_buffers = "128MB";
+        huge_pages = "try";
+      };
+
+      identMap = ''
+        superuser_map      root                postgres
+        superuser_map      postgres            postgres
+        superuser_map      postgres-exporter   postgres
+        superuser_map      ${user}             postgres
+        # Let other names login as themselves
+        superuser_map      /^(.*)$             \1
+      '';
+
+      initdbArgs = [
+        "--data-checksums"
+        "--allow-group-access"
+      ];
+
+      # https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+      authentication = lib.mkForce ''
+        # TYPE  DATABASE        USER            ADDRESS                 METHOD   OPTIONS
+
+        # "local" is for Unix domain socket connections only
+        local   all             all                                     peer     map=superuser_map
+        # IPv4 local connections:
+        host    all             all             127.0.0.1/32            trust
+        # IPv6 local connections:
+        host    all             all             ::1/128                 trust
+
+        # Allow replication connections from localhost, by a user with the
+        # replication privilege.
+        local   replication     all                                     trust
+        host    replication     all             127.0.0.1/32            trust
+        host    replication     all             ::1/128                 trust
+
+        # Other Remote Access - allow access only the database with the same name as the user
+        host    sameuser        all             0.0.0.0/0               scram-sha-256
+      '';
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [5432];
+
+    preservation'.os.directories = [
+      "/var/lib/postgresql"
+    ];
+  };
+}


### PR DESCRIPTION
## 概要

- 新增可配置的 PostgreSQL NixOS 服务模块
- 使用 PostgreSQL 18，启用 JIT，数据存放在持久化的 `/var/lib/postgresql`
- 可选启用 TCP 访问，并在防火墙开放 5432 端口

## 检查

- `alejandra --check .` ✅
- `deadnix --fail .` ✅
- `nix-instantiate --parse modules/nixos/base/services/postgresql.nix` ✅
- `nix flake check path:. --no-build --all-systems` ⚠️ 因本地 Lix daemon socket 不可用而受阻
