### PR TITLE
fix(nixos): 替换已移除的 GTK 主题

### DIFF
--- a/modules/nixos/desktop/themes.nix
+++ b/modules/nixos/desktop/themes.nix
@@ -21,10 +21,10 @@ in {
       gtk = {
         enable = true;
 
-      theme = {
-        package = pkgs.adw-gtk3;
-        name = "adw-gtk3-dark";
-      };
+        theme = {
+          package = pkgs.adw-gtk3;
+          name = "adw-gtk3-dark";
+        };
 
         iconTheme = {
           package = pkgs.papirus-icon-theme;

--- a/modules/nixos/desktop/themes.nix
+++ b/modules/nixos/desktop/themes.nix
@@ -21,10 +21,10 @@ in {
       gtk = {
         enable = true;
 
-        theme = {
-          package = pkgs.flat-remix-gtk;
-          name = "Flat-Remix-GTK-Grey-Darkest";
-        };
+      theme = {
+        package = pkgs.adw-gtk3;
+        name = "adw-gtk3-dark";
+      };
 
         iconTheme = {
           package = pkgs.papirus-icon-theme;


### PR DESCRIPTION
## 概要
修复当前 nixpkgs 中已移除的 GTK 主题包，恢复桌面配置的完整可评估性。

## 变更内容
- 将 `flat-remix-gtk` 替换为 `adw-gtk3`
- 使用 `adw-gtk3-dark` 主题名称
- 保持现有 Home Manager GTK、图标和字体配置不变

## 验证
- `alejandra .`
- `deadnix --fail .`
- 所有 Nix 文件通过 `nix-instantiate --parse`
- `nix flake check --no-build`
