### PR TITLE
refactor(core): 统一共享系统选项

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -34,7 +34,7 @@ in {
   home = {
     username = myvars.username;
     inherit (platform) homeDirectory;
-    stateVersion = myvars.stateVersion;
+    stateVersion = "26.11";
   };
 
   programs = {

--- a/hosts/darwin/luna/default.nix
+++ b/hosts/darwin/luna/default.nix
@@ -1,4 +1,6 @@
 {
   # MacBook Pro M-series
+  system.stateVersion = 6;
+
   nixpkgs.hostPlatform = "aarch64-darwin";
 }

--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -1,4 +1,6 @@
 {...}: {
+  system.stateVersion = "26.11";
+
   imports = [
     ./hardware.nix
   ];

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -1,4 +1,6 @@
 {...}: {
+  system.stateVersion = "26.11";
+
   imports = [
     ./hardware.nix
   ];

--- a/modules/darwin/system/core.nix
+++ b/modules/darwin/system/core.nix
@@ -1,22 +1,46 @@
 {
+  config,
+  lib,
   hostName,
   myvars,
   ...
-}: {
-  programs.fish.enable = true;
+}: let
+  cfg = config.core';
+in {
+  imports = [
+    (lib.mkAliasOptionModule ["user'"] ["users" "users" myvars.username])
+    (lib.mkAliasOptionModule ["hm'"] ["home-manager" "users" myvars.username])
+  ];
 
-  time.timeZone = myvars.timeZone;
+  options.core' = {
+    hostName = lib.mkOption {
+      type = lib.types.str;
+      default = hostName;
+      description = "macOS host name";
+    };
 
-  system = {
-    primaryUser = myvars.username;
-    stateVersion = 6;
+    timeZone = lib.mkOption {
+      type = lib.types.str;
+      default = myvars.timeZone;
+      description = "System time zone";
+    };
   };
 
-  users.users.${myvars.username}.home = "/Users/${myvars.username}";
+  config = {
+    programs.fish.enable = lib.mkDefault true;
 
-  networking = {
-    inherit hostName;
-    computerName = hostName;
+    time.timeZone = lib.mkDefault cfg.timeZone;
+
+    system = {
+      primaryUser = myvars.username;
+    };
+
+    users.users.${myvars.username}.home = "/Users/${myvars.username}";
+
+    networking = {
+      hostName = cfg.hostName;
+      computerName = cfg.hostName;
+    };
+    system.defaults.smb.NetBIOSName = cfg.hostName;
   };
-  system.defaults.smb.NetBIOSName = hostName;
 }

--- a/modules/nixos/system/core.nix
+++ b/modules/nixos/system/core.nix
@@ -1,34 +1,69 @@
 {
+  config,
+  lib,
   hostName,
   myvars,
   ...
 }: let
-  userName = myvars.username;
-  hashedPassword = myvars.hashedPassword;
-  sshKeys = myvars.sshAuthorizedKeys;
+  cfg = config.core';
 in {
-  users.mutableUsers = false;
+  imports = [
+    (lib.mkAliasOptionModule ["user'"] ["users" "users" myvars.username])
+    (lib.mkAliasOptionModule ["hm'"] ["home-manager" "users" myvars.username])
+  ];
 
-  users.users = {
-    root = {
-      inherit hashedPassword;
-      openssh.authorizedKeys.keys = sshKeys;
+  options.core' = {
+    hostName = lib.mkOption {
+      type = lib.types.str;
+      default = hostName;
+      description = "NixOS host name";
     };
 
-    ${userName} = {
-      isNormalUser = true;
-      extraGroups = ["wheel"];
-      inherit hashedPassword;
-      openssh.authorizedKeys.keys = sshKeys;
+    timeZone = lib.mkOption {
+      type = lib.types.str;
+      default = myvars.timeZone;
+      description = "System time zone";
+    };
+
+    hashedPassword = lib.mkOption {
+      type = lib.types.str;
+      default = myvars.hashedPassword;
+      description = "Hashed password shared by the primary user and root";
+    };
+
+    sshAuthorizedKeys = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = myvars.sshAuthorizedKeys;
+      description = "SSH keys authorized for the primary user and root";
     };
   };
 
-  networking.hostName = hostName;
-  time.timeZone = myvars.timeZone;
-  system.stateVersion = myvars.stateVersion;
+  config = {
+    users.mutableUsers = false;
 
-  documentation = {
-    man.cache.enable = false;
-    nixos.enable = false;
+    users.users = {
+      root = {
+        hashedPassword = cfg.hashedPassword;
+        openssh.authorizedKeys.keys = cfg.sshAuthorizedKeys;
+      };
+
+      ${myvars.username} = {
+        isNormalUser = true;
+        extraGroups = ["wheel"];
+        hashedPassword = cfg.hashedPassword;
+        openssh.authorizedKeys.keys = cfg.sshAuthorizedKeys;
+      };
+    };
+
+    networking.hostName = cfg.hostName;
+    time.timeZone = lib.mkDefault cfg.timeZone;
+
+    # Add the terminfo database of all known terminals to the system profile.
+    environment.enableAllTerminfo = lib.mkDefault true;
+
+    documentation = {
+      man.cache.enable = false;
+      nixos.enable = false;
+    };
   };
 }

--- a/vars/default.nix
+++ b/vars/default.nix
@@ -5,8 +5,6 @@
 
   timeZone = "Asia/Singapore";
 
-  stateVersion = "26.11";
-
   hashedPassword = "$y$j9T$fXIHIyb1usprTzAw.ntqJ/$I/sbwudS.KESDGLwKV8QzsLqr7pNQvYYv20GcWKFsV1";
 
   sshAuthorizedKeys = [


### PR DESCRIPTION
## 概要
整理 NixOS 和 nix-darwin 的共享核心配置，让主机元数据、用户入口和状态版本有明确归属。

## 变更内容
- 为 NixOS 和 nix-darwin 增加统一的 `core'` 选项
- 提供 `user'` 和 `hm'` 快捷入口，统一访问主用户与 Home Manager 配置
- 将主机名、时区、密码哈希和 SSH 公钥纳入核心选项
- 将 `system.stateVersion` 放回各自的主机配置
- 将 Home Manager 的 `home.stateVersion` 放在 `home/default.nix`
- 将通用 terminfo 配置放入 NixOS 系统核心模块
- 从全局变量中移除系统状态版本，避免不同平台共用不合适的状态配置

## 验证
- `alejandra .`
- `deadnix --fail .`
- 所有 Nix 文件通过 `nix-instantiate --parse`
- `nix flake check --no-build`
