### PR TITLE
refactor(home): 集中 Home Manager 应用入口

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -39,6 +39,5 @@ in {
 
   programs = {
     man.enable = false;
-    man.generateCaches = false;
   };
 }

--- a/home/nixos/apps/firefox.nix
+++ b/home/nixos/apps/firefox.nix
@@ -1,3 +1,13 @@
 {
-  programs.firefox.enable = true;
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.home'.apps.firefox;
+in {
+  options.home'.apps.firefox.enable = lib.mkEnableOption "Firefox";
+
+  config = lib.mkIf cfg.enable {
+    programs.firefox.enable = true;
+  };
 }

--- a/home/nixos/apps/kitty.nix
+++ b/home/nixos/apps/kitty.nix
@@ -1,23 +1,33 @@
 {
-  programs.kitty = {
-    enable = true;
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.home'.apps.kitty;
+in {
+  options.home'.apps.kitty.enable = lib.mkEnableOption "Kitty terminal emulator";
 
-    font = {
-      name = "Maple Mono NF CN";
-      size = 12;
-    };
+  config = lib.mkIf cfg.enable {
+    programs.kitty = {
+      enable = true;
 
-    settings = {
-      background_opacity = "0.8";
-      confirm_os_window_close = 0;
-      hide_window_decorations = "titlebar-only";
-      mouse_hide_wait = 2;
-      tab_bar_edge = "top";
-      tab_bar_style = "powerline";
-      tab_powerline_style = "slanted";
-      url_color = "#ffb4a8";
-      url_style = "dotted";
-      window_padding_width = 10;
+      font = {
+        name = "Maple Mono NF CN";
+        size = 12;
+      };
+
+      settings = {
+        background_opacity = "0.8";
+        confirm_os_window_close = 0;
+        hide_window_decorations = "titlebar-only";
+        mouse_hide_wait = 2;
+        tab_bar_edge = "top";
+        tab_bar_style = "powerline";
+        tab_powerline_style = "slanted";
+        url_color = "#ffb4a8";
+        url_style = "dotted";
+        window_padding_width = 10;
+      };
     };
   };
 }

--- a/home/nixos/apps/telegram.nix
+++ b/home/nixos/apps/telegram.nix
@@ -1,3 +1,14 @@
-{pkgs, ...}: {
-  home.packages = [pkgs.ayugram-desktop];
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.home'.apps.telegram;
+in {
+  options.home'.apps.telegram.enable = lib.mkEnableOption "AyuGram Desktop";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [pkgs.ayugram-desktop];
+  };
 }

--- a/home/nixos/apps/vscode.nix
+++ b/home/nixos/apps/vscode.nix
@@ -1,16 +1,27 @@
-{pkgs, ...}: {
-  programs.vscode = {
-    enable = true;
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.home'.apps.vscode;
+in {
+  options.home'.apps.vscode.enable = lib.mkEnableOption "Visual Studio Code";
 
-    # Nixpkgs restores this integrity-sensitive binary after fixup, but the
-    # copied file loses its executable bit and extension verification fails
-    # with EACCES before the verifier can run.
-    package = pkgs.vscode.overrideAttrs (oldAttrs: {
-      postFixup =
-        (oldAttrs.postFixup or "")
-        + ''
-          chmod +x "$out/lib/vscode/resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign"
-        '';
-    });
+  config = lib.mkIf cfg.enable {
+    programs.vscode = {
+      enable = true;
+
+      # Nixpkgs restores this integrity-sensitive binary after fixup, but the
+      # copied file loses its executable bit and extension verification fails
+      # with EACCES before the verifier can run.
+      package = pkgs.vscode.overrideAttrs (oldAttrs: {
+        postFixup =
+          (oldAttrs.postFixup or "")
+          + ''
+            chmod +x "$out/lib/vscode/resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign"
+          '';
+      });
+    };
   };
 }

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -1,6 +1,13 @@
 {...}: {
   system.stateVersion = "26.11";
 
+  hm'.home'.apps = {
+    firefox.enable = true;
+    kitty.enable = true;
+    telegram.enable = true;
+    vscode.enable = true;
+  };
+
   imports = [
     ./hardware.nix
   ];

--- a/modules/nixos/desktop/applications.nix
+++ b/modules/nixos/desktop/applications.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  myvars,
   pkgs,
   ...
 }: let
@@ -38,7 +37,7 @@ in {
     services.gvfs.enable = true;
     services.udisks2.enable = true;
 
-    home-manager.users.${myvars.username}.xdg.mimeApps = {
+    hm'.xdg.mimeApps = {
       enable = true;
 
       # Home Manager derives all supported MIME types from the applications'

--- a/modules/nixos/desktop/cursors.nix
+++ b/modules/nixos/desktop/cursors.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  myvars,
   pkgs,
   ...
 }: let
@@ -12,7 +11,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home-manager.users.${myvars.username}.home.pointerCursor = {
+    hm'.home.pointerCursor = {
       enable = true;
       package = pkgs.bibata-cursors;
       name = "Bibata-Modern-Classic";

--- a/modules/nixos/desktop/themes.nix
+++ b/modules/nixos/desktop/themes.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  myvars,
   pkgs,
   ...
 }: let
@@ -12,35 +11,33 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home-manager.users.${myvars.username} = {
-      home.packages = with pkgs; [
-        gtk3
-        gtk4
-      ];
+    hm'.home.packages = with pkgs; [
+      gtk3
+      gtk4
+    ];
 
-      gtk = {
-        enable = true;
+    hm'.gtk = {
+      enable = true;
 
-        theme = {
-          package = pkgs.adw-gtk3;
-          name = "adw-gtk3-dark";
-        };
-
-        iconTheme = {
-          package = pkgs.papirus-icon-theme;
-          name = "Papirus-Dark";
-        };
-
-        font = {
-          package = pkgs.cantarell-fonts;
-          name = "Cantarell Regular";
-          size = 12;
-        };
+      theme = {
+        package = pkgs.adw-gtk3;
+        name = "adw-gtk3-dark";
       };
 
-      dconf.settings."org/gnome/desktop/interface" = {
-        color-scheme = "prefer-dark";
+      iconTheme = {
+        package = pkgs.papirus-icon-theme;
+        name = "Papirus-Dark";
       };
+
+      font = {
+        package = pkgs.cantarell-fonts;
+        name = "Cantarell Regular";
+        size = 12;
+      };
+    };
+
+    hm'.dconf.settings."org/gnome/desktop/interface" = {
+      color-scheme = "prefer-dark";
     };
   };
 }

--- a/modules/nixos/system/nix.nix
+++ b/modules/nixos/system/nix.nix
@@ -3,19 +3,21 @@
   myvars,
   pkgs,
   ...
-}: {
+}: let
+  user = myvars.username;
+in {
   nix = {
     package = pkgs.nix;
     gc.dates = lib.mkDefault "weekly";
     settings = {
       substituters = lib.mkAfter ["https://attic.xuyh0120.win/lantian"];
       trusted-public-keys = lib.mkAfter ["lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc="];
-      trusted-users = [myvars.username];
+      trusted-users = [user];
     };
   };
 
   programs.nh = {
     enable = true;
-    flake = "/home/${myvars.username}/nix-config";
+    flake = lib.mkDefault "/home/${user}/Dotfiles";
   };
 }


### PR DESCRIPTION
## 概要
为 Home Manager 应用建立明确的启用边界，并统一 NixOS 桌面模块访问主用户配置的入口。

## 变更内容
- 为 Firefox、Kitty、Telegram 和 Visual Studio Code 增加独立的 `home'.apps.<name>.enable` 开关
- 在 Elaina 主机中显式启用需要的 Home Manager 应用
- NixOS 桌面应用、光标和主题模块统一通过 `hm'` 访问主用户配置
- 移除 Home Manager 中不必要的 man 缓存配置
- 将 `nh` 的 flake 路径更新为当前仓库路径 `/home/<user>/Dotfiles`

## 验证
- `alejandra .`
- `deadnix --fail .`
- 所有 Nix 文件通过 `nix-instantiate --parse`
- `nix flake check --no-build`
