### PR TITLE
refactor(services): 让功能模块直接启用底层服务

### DIFF
--- a/modules/nixos/apps/postgresql.nix
+++ b/modules/nixos/apps/postgresql.nix
@@ -5,23 +5,42 @@
   pkgs,
   ...
 }: let
-  cfg = config.apps'.postgresql;
+  cfg = config.services'.postgresql;
   user = myvars.username;
 in {
-  options.apps'.postgresql = {
+  options.services'.postgresql = {
     enable = lib.mkEnableOption "Enable PostgreSQL service";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.postgresql_18;
+      description = "PostgreSQL package to use";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/postgresql";
+      description = "Directory in which PostgreSQL stores its data";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 5432;
+      description = "TCP port used by PostgreSQL";
+    };
+
     openFirewall = lib.mkEnableOption "Open firewall port for PostgreSQL";
   };
 
   config = lib.mkIf cfg.enable {
     services.postgresql = {
       enable = true;
-      package = pkgs.postgresql_18;
+      inherit (cfg) package dataDir;
       enableJIT = true;
       enableTCPIP = cfg.openFirewall;
 
       settings = {
-        port = 5432;
+        port = cfg.port;
         max_connections = 100;
         log_connections = true;
         log_statement = "ddl";
@@ -68,10 +87,7 @@ in {
       '';
     };
 
-    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [5432];
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [cfg.port];
 
-    preservation'.os.directories = [
-      "/var/lib/postgresql"
-    ];
   };
 }

--- a/modules/nixos/apps/postgresql.nix
+++ b/modules/nixos/apps/postgresql.nix
@@ -88,6 +88,5 @@ in {
     };
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [cfg.port];
-
   };
 }

--- a/modules/nixos/services/btrfs-scrub.nix
+++ b/modules/nixos/services/btrfs-scrub.nix
@@ -7,12 +7,18 @@
 in {
   options.services'.btrfs-scrub = {
     enable = lib.mkEnableOption "monthly Btrfs data scrubbing";
+
+    interval = lib.mkOption {
+      type = lib.types.str;
+      default = "monthly";
+      description = "Systemd calendar expression controlling scrub frequency";
+    };
   };
 
   config = lib.mkIf cfg.enable {
     services.btrfs.autoScrub = {
       enable = true;
-      interval = "monthly";
+      inherit (cfg) interval;
     };
   };
 }

--- a/modules/nixos/services/networkmanager.nix
+++ b/modules/nixos/services/networkmanager.nix
@@ -1,19 +1,17 @@
 {
   config,
   lib,
-  myvars,
   ...
 }: let
   cfg = config.services'.networkmanager;
-  user = myvars.username;
 in {
   options.services'.networkmanager = {
     enable = lib.mkEnableOption "NetworkManager for network configuration";
   };
 
   config = lib.mkIf cfg.enable {
-    networking.networkmanager.enable = lib.mkDefault true;
+    networking.networkmanager.enable = true;
 
-    users.users.${user}.extraGroups = ["networkmanager"];
+    user'.extraGroups = ["networkmanager"];
   };
 }

--- a/modules/nixos/services/openssh.nix
+++ b/modules/nixos/services/openssh.nix
@@ -7,22 +7,31 @@
 in {
   options.services'.openssh = {
     enable = lib.mkEnableOption "OpenSSH daemon";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 233;
+      description = "TCP port on which OpenSSH listens";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to open the SSH port in the firewall";
+    };
   };
 
   config = lib.mkIf cfg.enable {
     services.openssh = {
-      enable = lib.mkDefault true;
-      ports = lib.mkDefault [233];
+      enable = true;
+      ports = [cfg.port];
       settings = {
         # root user is used for remote deployment, so we need to allow it
         PermitRootLogin = lib.mkDefault "prohibit-password";
         PasswordAuthentication = lib.mkDefault false;
       };
-      openFirewall = lib.mkDefault true;
+      openFirewall = cfg.openFirewall;
     };
 
-    # Add terminfo database of all known terminals to the system profile.
-    # https://github.com/NixOS/nixpkgs/blob/nixos-25.05/nixos/modules/config/terminfo.nix
-    environment.enableAllTerminfo = lib.mkDefault true;
   };
 }

--- a/modules/nixos/services/openssh.nix
+++ b/modules/nixos/services/openssh.nix
@@ -32,6 +32,5 @@ in {
       };
       openFirewall = cfg.openFirewall;
     };
-
   };
 }

--- a/modules/nixos/services/printing.nix
+++ b/modules/nixos/services/printing.nix
@@ -10,6 +10,6 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    services.printing.enable = lib.mkDefault true;
+    services.printing.enable = true;
   };
 }

--- a/modules/nixos/services/vnstat.nix
+++ b/modules/nixos/services/vnstat.nix
@@ -10,6 +10,6 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    services.vnstat.enable = lib.mkDefault true;
+    services.vnstat.enable = true;
   };
 }

--- a/modules/nixos/services/zram.nix
+++ b/modules/nixos/services/zram.nix
@@ -7,6 +7,30 @@
 in {
   options.services'.zram = {
     enable = lib.mkEnableOption "compressed RAM swap with Zram";
+
+    algorithm = lib.mkOption {
+      type = lib.types.str;
+      default = "zstd";
+      description = "Compression algorithm used by Zram";
+    };
+
+    memoryPercent = lib.mkOption {
+      type = lib.types.ints.between 1 100;
+      default = 50;
+      description = "Maximum Zram swap size as a percentage of system memory";
+    };
+
+    memoryMax = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      description = "Optional absolute maximum Zram swap size in bytes";
+    };
+
+    priority = lib.mkOption {
+      type = lib.types.int;
+      default = 100;
+      description = "Swap priority for the Zram device";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -19,12 +43,13 @@ in {
       zswap.enable = false;
     };
 
-    zramSwap = {
-      enable = true;
-      algorithm = "zstd";
-      memoryPercent = 50;
-      memoryMax = 8 * 1024 * 1024 * 1024;
-      priority = 100;
-    };
+    zramSwap =
+      {
+        enable = true;
+        inherit (cfg) algorithm memoryPercent priority;
+      }
+      // lib.optionalAttrs (cfg.memoryMax != null) {
+        memoryMax = cfg.memoryMax;
+      };
   };
 }

--- a/modules/nixos/system/firewall.nix
+++ b/modules/nixos/system/firewall.nix
@@ -12,10 +12,10 @@ in {
   config = lib.mkIf cfg.enable {
     networking = {
       firewall = {
-        enable = lib.mkDefault true;
-        allowPing = lib.mkDefault true;
+        enable = true;
+        allowPing = true;
       };
-      nftables.enable = lib.mkDefault true;
+      nftables.enable = true;
     };
   };
 }

--- a/modules/nixos/system/fish.nix
+++ b/modules/nixos/system/fish.nix
@@ -1,8 +1,4 @@
-{
-  myvars,
-  pkgs,
-  ...
-}: {
+{pkgs, ...}: {
   programs.fish = {
     enable = true;
     useBabelfish = true;
@@ -11,5 +7,5 @@
     '';
   };
 
-  users.users.${myvars.username}.shell = pkgs.fish;
+  user'.shell = pkgs.fish;
 }

--- a/modules/nixos/system/systemd-boot.nix
+++ b/modules/nixos/system/systemd-boot.nix
@@ -1,6 +1,5 @@
 {lib, ...}: {
   boot.loader.systemd-boot = {
-    enable = lib.mkDefault false;
     editor = lib.mkDefault false;
     consoleMode = lib.mkDefault "max";
     configurationLimit = lib.mkDefault 8;


### PR DESCRIPTION
## 概要
整理 NixOS 服务模块的功能边界，使自定义模块开关成为底层服务配置的唯一入口，并把可调整的服务参数暴露在模块选项中。

## 变更内容
- NetworkManager、OpenSSH、Printing、VNStat 和 Firewall 由各自模块直接启用底层服务
- OpenSSH 暴露端口和防火墙开关选项
- Btrfs scrub 暴露执行周期选项
- Zram 暴露压缩算法、内存比例、上限和优先级选项
- Fish 通过 `user'` 统一设置主用户 shell
- PostgreSQL 统一使用 `services'.postgresql` 系统服务命名空间，并支持包、数据目录和端口配置
- 将通用 terminfo 配置从 OpenSSH 模块中移出
- 删除无实际作用的 systemd-boot 默认启用值

## 验证
- `alejandra .`
- `deadnix --fail .`
- 所有 Nix 文件通过 `nix-instantiate --parse`
- `nix flake check --no-build`
