### PR TITLE
refactor(persistence): 将状态限定于已启用的功能

### DIFF
--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -1,7 +1,10 @@
 {...}: {
   system.stateVersion = "26.11";
 
-  storage'.persistence.enable = true;
+  storage'.persistence = {
+    enable = true;
+    desktop.enable = true;
+  };
 
   hm'.home'.apps = {
     firefox.enable = true;

--- a/modules/nixos/apps/postgresql.nix
+++ b/modules/nixos/apps/postgresql.nix
@@ -88,5 +88,7 @@ in {
     };
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [cfg.port];
+
+    preservation'.os.directories = [cfg.dataDir];
   };
 }

--- a/modules/nixos/services/networkmanager.nix
+++ b/modules/nixos/services/networkmanager.nix
@@ -13,5 +13,13 @@ in {
     networking.networkmanager.enable = true;
 
     user'.extraGroups = ["networkmanager"];
+
+    preservation'.os.directories = [
+      {
+        directory = "/etc/NetworkManager/system-connections";
+        mode = "0700";
+      }
+      "/var/lib/NetworkManager"
+    ];
   };
 }

--- a/modules/nixos/services/openssh.nix
+++ b/modules/nixos/services/openssh.nix
@@ -32,5 +32,7 @@ in {
       };
       openFirewall = cfg.openFirewall;
     };
+
+    preservation'.os.directories = ["/etc/ssh"];
   };
 }

--- a/modules/nixos/services/printing.nix
+++ b/modules/nixos/services/printing.nix
@@ -11,5 +11,23 @@ in {
 
   config = lib.mkIf cfg.enable {
     services.printing.enable = true;
+
+    preservation'.os.directories = [
+      {
+        directory = "/var/cache/cups";
+        group = "lp";
+        mode = "0770";
+      }
+      {
+        directory = "/var/lib/cups";
+        user = "cups";
+        group = "lp";
+      }
+      {
+        directory = "/var/spool/cups";
+        group = "lp";
+        mode = "0710";
+      }
+    ];
   };
 }

--- a/modules/nixos/services/smartd.nix
+++ b/modules/nixos/services/smartd.nix
@@ -35,5 +35,12 @@ in {
       StateDirectory = "smartmontools";
       StateDirectoryMode = "0750";
     };
+
+    preservation'.os.directories = [
+      {
+        directory = "/var/lib/smartmontools";
+        mode = "0750";
+      }
+    ];
   };
 }

--- a/modules/nixos/services/vnstat.nix
+++ b/modules/nixos/services/vnstat.nix
@@ -11,5 +11,13 @@ in {
 
   config = lib.mkIf cfg.enable {
     services.vnstat.enable = true;
+
+    preservation'.os.directories = [
+      {
+        directory = "/var/lib/vnstat";
+        user = "vnstatd";
+        group = "vnstatd";
+      }
+    ];
   };
 }

--- a/modules/nixos/storage/persistence-desktop.nix
+++ b/modules/nixos/storage/persistence-desktop.nix
@@ -1,0 +1,129 @@
+{
+  config,
+  lib,
+  myvars,
+  ...
+}: let
+  cfg = config.storage'.persistence;
+  user = myvars.username;
+  hmApps = config.home-manager.users.${user}.home'.apps;
+in {
+  config = lib.mkIf cfg.desktop.enable {
+    # Shared desktop state is enabled as a group; application state below is
+    # added only when the corresponding feature is enabled.
+    preservation'.user.directories =
+      [
+        {
+          directory = ".config/gtk-3.0";
+          mode = "0700";
+        }
+        {
+          directory = ".config/dconf";
+          mode = "0700";
+        }
+        {
+          directory = ".local/share/keyrings";
+          mode = "0700";
+        }
+        {
+          directory = ".local/share/pki";
+          mode = "0700";
+        }
+      ]
+      ++ lib.optionals config.desktop'.applications.enable [
+        # Desktop application launchers and file manager metadata
+        {
+          directory = ".local/share/applications";
+          mode = "0700";
+        }
+        {
+          directory = ".local/share/Trash";
+          mode = "0700";
+        }
+        {
+          directory = ".local/share/gvfs-metadata";
+          mode = "0700";
+        }
+      ]
+      ++ lib.optionals config.desktop'.dms.enable [
+        # DankMaterialShell
+        ".config/DankMaterialShell"
+        {
+          directory = ".local/state/DankMaterialShell";
+          mode = "0700";
+        }
+      ]
+      ++ lib.optionals config.desktop'.fcitx5.enable [
+        # Fcitx5
+        ".config/fcitx5"
+        ".local/share/fcitx5"
+      ]
+      ++ lib.optionals hmApps.firefox.enable [
+        # Firefox
+        ".config/mozilla"
+        ".mozilla"
+      ]
+      ++ lib.optionals config.desktop'.niri.enable [
+        # Niri
+        ".config/niri"
+      ]
+      ++ lib.optionals (config.desktop'.cursors.enable || config.desktop'.themes.enable) [
+        # GTK and icon themes
+        ".icons"
+      ]
+      ++ lib.optionals hmApps.telegram.enable [
+        # Telegram
+        ".local/share/AyuGramDesktop"
+      ]
+      ++ lib.optionals (config.services.pulseaudio.enable || config.services.pipewire.pulse.enable) [
+        # PulseAudio compatibility cookie
+        {
+          directory = ".config/pulse";
+          mode = "0700";
+        }
+      ]
+      ++ lib.optionals hmApps.vscode.enable [
+        # Visual Studio Code
+        ".config/Code"
+        ".vscode"
+        ".vscode-shared"
+      ]
+      ++ lib.optionals config.services.pipewire.wireplumber.enable [
+        # WirePlumber
+        {
+          directory = ".local/state/wireplumber";
+          mode = "0700";
+        }
+      ];
+
+    preservation'.os.directories =
+      lib.optionals config.services.accounts-daemon.enable [
+        {
+          directory = "/var/lib/AccountsService";
+          mode = "0775";
+        }
+      ]
+      ++ lib.optionals config.hardware.bluetooth.enable [
+        # Bluetooth
+        {
+          directory = "/var/lib/bluetooth";
+          mode = "0700";
+        }
+      ]
+      ++ lib.optionals config.services.power-profiles-daemon.enable [
+        # Power management
+        "/var/lib/power-profiles-daemon"
+      ]
+      ++ lib.optionals config.services.upower.enable [
+        "/var/lib/upower"
+      ]
+      ++ lib.optionals config.services.greetd.enable [
+        # Tuigreet
+        {
+          directory = "/var/cache/tuigreet";
+          user = "greeter";
+          group = "greeter";
+        }
+      ];
+  };
+}

--- a/modules/nixos/system/firewall.nix
+++ b/modules/nixos/system/firewall.nix
@@ -17,5 +17,7 @@ in {
       };
       nftables.enable = true;
     };
+
+    preservation'.os.directories = ["/var/lib/nftables"];
   };
 }

--- a/modules/nixos/system/fish.nix
+++ b/modules/nixos/system/fish.nix
@@ -8,4 +8,9 @@
   };
 
   user'.shell = pkgs.fish;
+
+  preservation'.user.directories = [
+    ".config/fish"
+    ".local/share/fish"
+  ];
 }


### PR DESCRIPTION
## 概要
让服务和桌面应用只声明自己实际拥有的持久化状态，避免未启用功能占用 `/persistent`。

## 变更内容
- 将 NetworkManager、OpenSSH、VNStat、Printing、Smartd、Firewall、Fish 和 PostgreSQL 的状态放回各自模块
- 服务状态只在对应的 `services'` 或系统功能开关启用时声明
- 新增桌面持久化模块，按桌面功能和 Home Manager 应用开关分别处理状态
- Firefox、Telegram、Visual Studio Code 等应用只在启用时持久化自己的目录
- 根据 AccountsService、Bluetooth、Power Profiles、UPower、greetd 和音频服务的实际启用状态处理系统目录
- 将 Elaina 主机配置为启用桌面持久化分组
- 保持基础 `persistence.nix` 只负责系统基础和跨主机共用状态

## 验证
- `alejandra .`
- `deadnix --fail .`
- 所有 Nix 文件通过 `nix-instantiate --parse`
- `nix flake check --no-build`
