### PR TITLE
refactor(darwin): 将系统集成改为显式启用

### DIFF
--- a/hosts/darwin/luna/default.nix
+++ b/hosts/darwin/luna/default.nix
@@ -1,6 +1,12 @@
 {
   # MacBook Pro M-series
+  ...
+}: {
   system.stateVersion = 6;
+
+  apps'.homebrew.enable = true;
+  security'.touch-id.enable = true;
+  system'.defaults.enable = true;
 
   nixpkgs.hostPlatform = "aarch64-darwin";
 }

--- a/modules/darwin/apps/homebrew.nix
+++ b/modules/darwin/apps/homebrew.nix
@@ -1,97 +1,144 @@
 {
-  homebrew = {
-    enable = true;
-    enableFishIntegration = true;
-    enableZshIntegration = true;
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.apps'.homebrew;
+in {
+  options.apps'.homebrew = {
+    enable = lib.mkEnableOption "Homebrew package management";
+
+    enableFishIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable Homebrew integration for Fish";
+    };
+
+    enableZshIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable Homebrew integration for Zsh";
+    };
 
     onActivation = {
-      autoUpdate = true; # Fetch the newest stable branch of Homebrew's git repo
-      cleanup = "zap"; # Uninstall unlisted packages and their related files
-      upgrade = true; # Upgrade outdated casks, formulae, and App Store apps
+      autoUpdate = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Fetch the newest stable Homebrew branch on activation";
+      };
+
+      cleanup = lib.mkOption {
+        type = lib.types.enum ["none" "uninstall" "zap"];
+        default = "zap";
+        description = "How aggressively to remove packages not in the configuration";
+      };
+
+      upgrade = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Upgrade outdated Homebrew packages on activation";
+      };
     };
 
-    # Applications to install from Mac App Store using mas.
-    masApps = {
-      "Bob" = 1630034110;
-      "WPS" = 1443749478;
+    masApps = lib.mkOption {
+      type = lib.types.attrsOf lib.types.int;
+      default = {
+        "Bob" = 1630034110;
+        "WPS" = 1443749478;
+      };
+      description = "Applications to install from the Mac App Store";
     };
 
-    # `brew install`
-    brews = [
-      # Disk & Cleanup
-      "mole"
-    ];
+    brews = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        # Disk & Cleanup
+        "mole"
+      ];
+      description = "Homebrew formulae to install";
+    };
 
-    # `brew install --cask`
-    casks = [
-      # AI Development
-      "chatgpt"
-      "cc-switch"
-      "grok-build"
-      "steipete/tap/codexbar"
+    casks = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        # AI Development
+        "chatgpt"
+        "cc-switch"
+        "grok-build"
+        "steipete/tap/codexbar"
 
-      # Browser
-      # "brave-browser"
-      "firefox"
-      "google-chrome"
+        # Browser
+        # "brave-browser"
+        "firefox"
+        "google-chrome"
 
-      # Communication
-      "feishu"
-      "telegram"
-      "wechat"
+        # Communication
+        "feishu"
+        "telegram"
+        "wechat"
 
-      # Development
-      "orbstack"
+        # Development
+        "orbstack"
 
-      # Editor
-      "visual-studio-code"
+        # Editor
+        "visual-studio-code"
 
-      # Font
-      "font-lxgw-wenkai"
-      "font-hack-nerd-font"
-      "font-material-icons"
-      "font-maple-mono-nf-cn"
-      "font-jetbrains-mono-nerd-font"
+        # Font
+        "font-lxgw-wenkai"
+        "font-hack-nerd-font"
+        "font-material-icons"
+        "font-maple-mono-nf-cn"
+        "font-jetbrains-mono-nerd-font"
 
-      # Hardware
-      # "monitorcontrol"
-      "macs-fan-control"
+        # Hardware
+        # "monitorcontrol"
+        "macs-fan-control"
 
-      # Input & Keyboard
-      "input-source-pro"
-      "karabiner-elements"
+        # Input & Keyboard
+        "input-source-pro"
+        "karabiner-elements"
 
-      # Knowledge Base
-      "obsidian"
+        # Knowledge Base
+        "obsidian"
 
-      # Media
-      "iina"
-      "neteasemusic"
-      "obs"
-      "plex"
+        # Media
+        "iina"
+        "neteasemusic"
+        "obs"
+        "plex"
 
-      # Menu Bar
-      "jordanbaird-ice@beta"
+        # Menu Bar
+        "jordanbaird-ice@beta"
 
-      # Network Tools
-      "surge"
+        # Network Tools
+        "surge"
 
-      # Productivity
-      "qspace-pro"
-      "raycast"
+        # Productivity
+        "qspace-pro"
+        "raycast"
 
-      # Remote Access
-      "uuremote"
+        # Remote Access
+        "uuremote"
 
-      # SSH Client
-      "termius"
+        # SSH Client
+        "termius"
 
-      # System Monitor
-      "stats"
+        # System Monitor
+        "stats"
 
-      # Terminal Emulator
-      "ghostty"
-      "kitty"
-    ];
+        # Terminal Emulator
+        "ghostty"
+        "kitty"
+      ];
+      description = "Homebrew casks to install";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    homebrew = {
+      enable = true;
+      inherit (cfg) enableFishIntegration enableZshIntegration masApps brews casks;
+      onActivation = cfg.onActivation;
+    };
   };
 }

--- a/modules/darwin/security/touch-id.nix
+++ b/modules/darwin/security/touch-id.nix
@@ -1,4 +1,11 @@
 {
-  # Allow Touch ID authentication for sudo.
-  security.pam.services.sudo_local.touchIdAuth = true;
+  config,
+  lib,
+  ...
+}: {
+  options.security'.touch-id.enable = lib.mkEnableOption "Touch ID authentication for sudo";
+
+  config = lib.mkIf config.security'.touch-id.enable {
+    security.pam.services.sudo_local.touchIdAuth = true;
+  };
 }

--- a/modules/darwin/system/defaults.nix
+++ b/modules/darwin/system/defaults.nix
@@ -9,112 +9,120 @@
 #
 ###################################################################################
 {
-  system.defaults = {
-    menuExtraClock.Show24Hour = true; # show 24 hour clock
-    menuExtraClock.ShowSeconds = true;
+  config,
+  lib,
+  ...
+}: {
+  options.system'.defaults.enable = lib.mkEnableOption "macOS system defaults";
 
-    # customize dock
-    dock = {
-      autohide = true; # 自动隐藏 Dock
-      show-recents = false; # 禁用最近应用
+  config = lib.mkIf config.system'.defaults.enable {
+    system.defaults = {
+      menuExtraClock.Show24Hour = true; # show 24 hour clock
+      menuExtraClock.ShowSeconds = true;
 
-      # 触发角
-      wvous-tl-corner = 2; # Mission Control
-      wvous-tr-corner = 4; # Desktop
-      wvous-bl-corner = 3; # Application Windows
-      wvous-br-corner = 13; # Lock Screen
-    };
+      # customize dock
+      dock = {
+        autohide = true; # 自动隐藏 Dock
+        show-recents = false; # 禁用最近应用
 
-    finder = {
-      _FXShowPosixPathInTitle = true; # 显示Finder标题中的完整路径
-      AppleShowAllExtensions = true; # 显示所有文件扩展名
-      FXEnableExtensionChangeWarning = false; # 更改文件扩展名时禁用警告
-      NewWindowTarget = "Home"; # 新 Finder 窗口默认显示用户主目录
-      QuitMenuItem = true; # 启用退出菜单项
-      ShowPathbar = true; # 显示路径栏
-      ShowStatusBar = true; # 显示状态栏
-    };
-
-    # trackpad = {
-    #   Clicking = true; # 是否启用点击
-    #   TrackpadRightClick = true; # 启用两指右键点击
-    #   TrackpadThreeFingerDrag = true; # 是否启用三指拖动
-    # };
-
-    NSGlobalDomain = {
-      "com.apple.swipescrolldirection" = true; # 启用自然滚动（默认为true）
-      "com.apple.sound.beep.feedback" = 0; # 系统音量改变时发出反馈声音。
-
-      # Appearance
-      AppleInterfaceStyle = "Dark"; # 深色模式
-
-      AppleKeyboardUIMode = 2; # 配置键盘控制行为
-
-      InitialKeyRepeat = 15; # 正常最小值为15（225毫秒），最大值为120（1800毫秒）
-      KeyRepeat = 3; # 正常最小值为2（30毫秒），最大值为120（1800毫秒）
-
-      NSAutomaticCapitalizationEnabled = false; # 是否启用自动大写
-      NSAutomaticDashSubstitutionEnabled = false; # 是否启用智能减号替换
-      NSAutomaticPeriodSubstitutionEnabled = false; # 是否启用智能句号替换
-      NSAutomaticQuoteSubstitutionEnabled = false; # 是否启用智能引号替换
-      NSAutomaticSpellingCorrectionEnabled = false; # 是否启用自动拼写检查
-      NSNavPanelExpandedStateForSaveMode = true; # 保存文件时的路径选择/文件名输入页
-      NSNavPanelExpandedStateForSaveMode2 = true; # 保存文件时的路径选择/文件名输入页
-    };
-
-    # Customize settings that not supported by nix-darwin directly
-    # see the source code of this project to get more undocumented options:
-    #    https://github.com/rgcr/m-cli
-    #
-    # All custom entries can be found by running `defaults read` command.
-    # or `defaults read xxx` to read a specific domain.
-    CustomUserPreferences = {
-      ".GlobalPreferences" = {
-        # automatically switch to a new space when switching to the application
-        AppleSpacesSwitchOnActivate = true;
+        # 触发角
+        wvous-tl-corner = 2; # Mission Control
+        wvous-tr-corner = 4; # Desktop
+        wvous-bl-corner = 3; # Application Windows
+        wvous-br-corner = 13; # Lock Screen
       };
+
+      finder = {
+        _FXShowPosixPathInTitle = true; # 显示Finder标题中的完整路径
+        AppleShowAllExtensions = true; # 显示所有文件扩展名
+        FXEnableExtensionChangeWarning = false; # 更改文件扩展名时禁用警告
+        NewWindowTarget = "Home"; # 新 Finder 窗口默认显示用户主目录
+        QuitMenuItem = true; # 启用退出菜单项
+        ShowPathbar = true; # 显示路径栏
+        ShowStatusBar = true; # 显示状态栏
+      };
+
+      # trackpad = {
+      #   Clicking = true; # 是否启用点击
+      #   TrackpadRightClick = true; # 启用两指右键点击
+      #   TrackpadThreeFingerDrag = true; # 是否启用三指拖动
+      # };
+
       NSGlobalDomain = {
-        # Add a context menu item for showing the Web Inspector in web views
-        WebKitDeveloperExtras = true;
+        "com.apple.swipescrolldirection" = true; # 启用自然滚动（默认为true）
+        "com.apple.sound.beep.feedback" = 0; # 系统音量改变时发出反馈声音。
+
+        # Appearance
+        AppleInterfaceStyle = "Dark"; # 深色模式
+
+        AppleKeyboardUIMode = 2; # 配置键盘控制行为
+
+        InitialKeyRepeat = 15; # 正常最小值为15（225毫秒），最大值为120（1800毫秒）
+        KeyRepeat = 3; # 正常最小值为2（30毫秒），最大值为120（1800毫秒）
+
+        NSAutomaticCapitalizationEnabled = false; # 是否启用自动大写
+        NSAutomaticDashSubstitutionEnabled = false; # 是否启用智能减号替换
+        NSAutomaticPeriodSubstitutionEnabled = false; # 是否启用智能句号替换
+        NSAutomaticQuoteSubstitutionEnabled = false; # 是否启用智能引号替换
+        NSAutomaticSpellingCorrectionEnabled = false; # 是否启用自动拼写检查
+        NSNavPanelExpandedStateForSaveMode = true; # 保存文件时的路径选择/文件名输入页
+        NSNavPanelExpandedStateForSaveMode2 = true; # 保存文件时的路径选择/文件名输入页
       };
-      "com.apple.finder" = {
-        ShowExternalHardDrivesOnDesktop = true;
-        ShowHardDrivesOnDesktop = false;
-        ShowMountedServersOnDesktop = true;
-        ShowRemovableMediaOnDesktop = true;
-        _FXSortFoldersFirst = true;
-        # When performing a search, search the current folder by default
-        FXDefaultSearchScope = "SCcf";
+
+      # Customize settings that not supported by nix-darwin directly
+      # see the source code of this project to get more undocumented options:
+      #    https://github.com/rgcr/m-cli
+      #
+      # All custom entries can be found by running `defaults read` command.
+      # or `defaults read xxx` to read a specific domain.
+      CustomUserPreferences = {
+        ".GlobalPreferences" = {
+          # automatically switch to a new space when switching to the application
+          AppleSpacesSwitchOnActivate = true;
+        };
+        NSGlobalDomain = {
+          # Add a context menu item for showing the Web Inspector in web views
+          WebKitDeveloperExtras = true;
+        };
+        "com.apple.finder" = {
+          ShowExternalHardDrivesOnDesktop = true;
+          ShowHardDrivesOnDesktop = false;
+          ShowMountedServersOnDesktop = true;
+          ShowRemovableMediaOnDesktop = true;
+          _FXSortFoldersFirst = true;
+          # When performing a search, search the current folder by default
+          FXDefaultSearchScope = "SCcf";
+        };
+        "com.apple.desktopservices" = {
+          # Avoid creating .DS_Store files on network or USB volumes
+          DSDontWriteNetworkStores = true;
+          DSDontWriteUSBStores = true;
+        };
+        "com.apple.spaces" = {
+          "spans-displays" = 0; # Display have seperate spaces
+        };
+        "com.apple.WindowManager" = {
+          EnableStandardClickToShowDesktop = 0; # Click wallpaper to reveal desktop
+          StandardHideDesktopIcons = 0; # Show items on desktop
+          HideDesktop = 0; # Do not hide items on desktop & stage manager
+          StageManagerHideWidgets = 0;
+          StandardHideWidgets = 0;
+        };
+        "com.apple.screensaver" = {
+          # Require password immediately after sleep or screen saver begins
+          askForPassword = 1;
+          askForPasswordDelay = 0;
+        };
+        "com.apple.screencapture" = {
+          location = "~/Desktop";
+          type = "png";
+        };
+        "com.apple.AdLib" = {
+          allowApplePersonalizedAdvertising = false;
+        };
+        # Prevent Photos from opening automatically when devices are plugged in
+        "com.apple.ImageCapture".disableHotPlug = true;
       };
-      "com.apple.desktopservices" = {
-        # Avoid creating .DS_Store files on network or USB volumes
-        DSDontWriteNetworkStores = true;
-        DSDontWriteUSBStores = true;
-      };
-      "com.apple.spaces" = {
-        "spans-displays" = 0; # Display have seperate spaces
-      };
-      "com.apple.WindowManager" = {
-        EnableStandardClickToShowDesktop = 0; # Click wallpaper to reveal desktop
-        StandardHideDesktopIcons = 0; # Show items on desktop
-        HideDesktop = 0; # Do not hide items on desktop & stage manager
-        StageManagerHideWidgets = 0;
-        StandardHideWidgets = 0;
-      };
-      "com.apple.screensaver" = {
-        # Require password immediately after sleep or screen saver begins
-        askForPassword = 1;
-        askForPasswordDelay = 0;
-      };
-      "com.apple.screencapture" = {
-        location = "~/Desktop";
-        type = "png";
-      };
-      "com.apple.AdLib" = {
-        allowApplePersonalizedAdvertising = false;
-      };
-      # Prevent Photos from opening automatically when devices are plugged in
-      "com.apple.ImageCapture".disableHotPlug = true;
     };
   };
 }


### PR DESCRIPTION
## 概要

将 Darwin 的系统集成模块改为显式启用，避免未选择的集成自动修改系统。

## 变更内容

- 为 Homebrew 增加 `apps'.homebrew.enable` 及可配置的软件清单和激活选项
- 为 Touch ID 增加 `security'.touch-id.enable`
- 为 macOS defaults 增加 `system'.defaults.enable`
- 在 Luna 主机中显式启用需要的 Darwin 集成
- 保持系统默认设置内容不变，仅调整启用边界

## 验证

- `alejandra .`
- `deadnix --fail .`
- 所有 Nix 文件通过 `nix-instantiate --parse`
- `nix flake check --no-build`
