### PR TITLE
feat(darwin): 通过 Homebrew cask 控制 Karabiner

### DIFF
--- a/home/darwin/apps/karabiner.nix
+++ b/home/darwin/apps/karabiner.nix
@@ -1,77 +1,86 @@
 {
-  home.file.".config/karabiner/karabiner.json".text = builtins.toJSON {
-    profiles = [
-      {
-        complex_modifications = {
-          rules = [
-            {
-              description = "Change right_command key to command+control+option+shift. (Post f19 key when pressed alone)";
-              manipulators = [
-                {
-                  from = {
-                    key_code = "right_command";
-                    modifiers.optional = ["any"];
-                  };
-                  to = [
-                    {
-                      key_code = "left_shift";
-                      modifiers = [
-                        "left_command"
-                        "left_control"
-                        "left_option"
-                      ];
-                    }
-                  ];
-                  to_if_alone = [
-                    {
-                      key_code = "f19";
-                    }
-                  ];
-                  type = "basic";
-                }
-              ];
-            }
-            {
-              description = "Click Control => Capslock , Long press Control => Control";
-              manipulators = [
-                {
-                  from = {
-                    key_code = "left_control";
-                    modifiers.optional = ["any"];
-                  };
-                  to = [
-                    {
+  lib,
+  osConfig,
+  ...
+}: let
+  brewCfg = osConfig.apps'.homebrew;
+  enabled = brewCfg.enable && lib.elem "karabiner-elements" brewCfg.casks;
+in {
+  config = lib.mkIf enabled {
+    home.file.".config/karabiner/karabiner.json".text = builtins.toJSON {
+      profiles = [
+        {
+          complex_modifications = {
+            rules = [
+              {
+                description = "Change right_command key to command+control+option+shift. (Post f19 key when pressed alone)";
+                manipulators = [
+                  {
+                    from = {
+                      key_code = "right_command";
+                      modifiers.optional = ["any"];
+                    };
+                    to = [
+                      {
+                        key_code = "left_shift";
+                        modifiers = [
+                          "left_command"
+                          "left_control"
+                          "left_option"
+                        ];
+                      }
+                    ];
+                    to_if_alone = [
+                      {
+                        key_code = "f19";
+                      }
+                    ];
+                    type = "basic";
+                  }
+                ];
+              }
+              {
+                description = "Click Control => Capslock , Long press Control => Control";
+                manipulators = [
+                  {
+                    from = {
                       key_code = "left_control";
-                    }
-                  ];
-                  to_if_alone = [
-                    {
-                      hold_down_milliseconds = 100;
-                      key_code = "caps_lock";
-                    }
-                  ];
-                  type = "basic";
-                }
-              ];
+                      modifiers.optional = ["any"];
+                    };
+                    to = [
+                      {
+                        key_code = "left_control";
+                      }
+                    ];
+                    to_if_alone = [
+                      {
+                        hold_down_milliseconds = 100;
+                        key_code = "caps_lock";
+                      }
+                    ];
+                    type = "basic";
+                  }
+                ];
+              }
+            ];
+          };
+          devices = [
+            {
+              disable_built_in_keyboard_if_exists = true;
+              identifiers = {
+                is_keyboard = true;
+                product_id = 33;
+                vendor_id = 1278;
+              };
             }
           ];
-        };
-        devices = [
-          {
-            disable_built_in_keyboard_if_exists = true;
-            identifiers = {
-              is_keyboard = true;
-              product_id = 33;
-              vendor_id = 1278;
-            };
-          }
-        ];
-        name = "Default profile";
-        selected = true;
-        virtual_hid_keyboard = {
-          keyboard_type_v2 = "ansi";
-        };
-      }
-    ];
+          name = "Default profile";
+          selected = true;
+          virtual_hid_keyboard = {
+            keyboard_type_v2 = "ansi";
+          };
+        }
+      ];
+    };
   };
 }


### PR DESCRIPTION
## 概要

让 Karabiner 配置跟随 Homebrew 的声明式安装状态，避免在未安装 Karabiner-Elements 时生成无效配置。

## 变更内容

- 移除 Karabiner 独立的 `enable` 选项
- 读取 nix-darwin 的 `apps'.homebrew.enable` 和 `casks`
- 仅当 Homebrew 已启用且 cask 列表包含 `karabiner-elements` 时生成配置文件
- 保留现有按键规则和设备标识，不改变按键行为
- 不再要求主机配置重复声明 Karabiner 开关

## 验证

- `alejandra .`
- `deadnix --fail .`
- 所有 Nix 文件通过 `nix-instantiate --parse`
- `nix flake check --no-build`
