### PR TITLE
refactor(storage): 统一 Disko 命名空间

### DIFF
--- a/hosts/nixos/beelink/hardware.nix
+++ b/hosts/nixos/beelink/hardware.nix
@@ -23,7 +23,7 @@
     efi.canTouchEfiVariables = true;
   };
 
-  hardware'.disko = {
+  storage'.disko = {
     enable = true;
     device = "/dev/disk/by-id/nvme-CT1000P3PSSD8_24364AD5D8E0";
     espSize = "1G";

--- a/hosts/nixos/beelink/hardware.nix
+++ b/hosts/nixos/beelink/hardware.nix
@@ -25,7 +25,7 @@
 
   storage'.disko = {
     enable = true;
-    device = "/dev/disk/by-id/nvme-CT1000P3PSSD8_24364AD5D8E0";
+    device = "/dev/nvme0n1";
     espSize = "1G";
     luks.enable = true;
   };

--- a/hosts/nixos/elaina/hardware.nix
+++ b/hosts/nixos/elaina/hardware.nix
@@ -23,7 +23,7 @@
     efi.canTouchEfiVariables = true;
   };
 
-  hardware'.disko = {
+  storage'.disko = {
     enable = true;
     device = "/dev/nvme0n1";
     espSize = "1G";

--- a/modules/nixos/storage/disko.nix
+++ b/modules/nixos/storage/disko.nix
@@ -4,7 +4,7 @@
   lib,
   ...
 }: let
-  cfg = config.hardware'.disko;
+  cfg = config.storage'.disko;
 
   btrfsSubvolumes =
     {
@@ -44,7 +44,7 @@
 in {
   imports = [inputs.disko.nixosModules.disko];
 
-  options.hardware'.disko = {
+  options.storage'.disko = {
     enable = lib.mkEnableOption "Disko disk management";
 
     device = lib.mkOption {


### PR DESCRIPTION
## 概要

补齐 Disko 配置与新的存储模块布局之间的命名空间迁移，并统一两台设备的实际磁盘设备路径。

## 变更内容

- 将 Disko 模块的配置选项从 `hardware'.disko` 统一为 `storage'.disko`
- 更新 Beelink 和 Elaina 硬件配置中的 Disko 引用
- 将 Beelink 和 Elaina 的设备路径统一为 `/dev/nvme0n1`
- 修正 Beelink 原有错误的 `/dev/disk/by-id/` 标识
- 不改变磁盘分区、LUKS、Btrfs 或 swap 配置

## 验证

- `alejandra .`
- `deadnix --fail .`
- 所有 Nix 文件通过 `nix-instantiate --parse`
- `nix flake check --no-build`
