### PR TITLE
ci: 新增 Nix 校验工作流

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,35 @@
+name: check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: Check formatting (alejandra)
+        run: nix run nixpkgs#alejandra -- --check .
+
+      - name: Check dead code (deadnix)
+        run: nix run nixpkgs#deadnix -- --fail .
+
+      - name: Parse all Nix files
+        run: |
+          set -e
+          for file in $(git ls-files '*.nix'); do
+            nix-instantiate --parse "$file" > /dev/null || exit 1
+          done
+
+      - name: Flake check
+        run: nix flake check --no-build


### PR DESCRIPTION
## 概要

新增 GitHub Actions 工作流，在 PR 和推送到 main 时自动执行 AGENTS.md 规定的全部本地验证，让 checks 状态成为合并依据。

## 变更内容

- 新增 `.github/workflows/check.yml`，在 `ubuntu-latest` 上运行：
  - `alejandra --check .`（格式检查）
  - `deadnix --fail .`（死代码检查）
  - 逐文件 `nix-instantiate --parse`
  - `nix flake check --no-build`
- 配置 concurrency 组，同一分支的新推送自动取消旧任务
- 求值类检查与平台无关；darwin 主机仅参与求值不参与构建，Linux runner 可完整覆盖

## 验证

- 本 PR 即新工作流的首次实测，见下方 checks 运行结果
