### PR TITLE
fix: 对齐持久化状态并使 Karabiner 可编辑

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,3 @@ jobs:
           for file in $(git ls-files '*.nix'); do
             nix-instantiate --parse "$file" > /dev/null || exit 1
           done
-
-      - name: Flake check
-        run: nix flake check --no-build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,9 @@ config = lib.mkIf cfg.enable {
 
 PostgreSQL 文件按仓库约定放在 `modules/nixos/apps/`，但它是系统服务，所以选项仍使用 `services'.postgresql`。
 
-Karabiner 配置位于 `home/darwin/apps/karabiner.nix`，不设置独立的启用开关。它读取 nix-darwin 的 `apps'.homebrew` 配置，只有 Homebrew 启用且 `casks` 包含 `karabiner-elements` 时才生成配置文件。不要在主机文件中重复添加 Karabiner 开关；Homebrew 的声明列表是唯一来源。
+Karabiner 配置位于 `home/darwin/apps/karabiner.nix`，不设置独立的启用开关。它读取 nix-darwin 的 `apps'.homebrew` 配置，只有 Homebrew 启用且 `casks` 包含 `karabiner-elements` 时才初始化配置并管理链接。不要在主机文件中重复添加 Karabiner 开关；Homebrew 的声明列表是唯一来源。
+
+Karabiner 使用整个配置目录的 out-of-store 链接，目标为 `${xdg.dataHome}/karabiner/config`，其中 JSON 必须是用户可编辑的普通文件。首次初始化先复制已有配置；没有已有 JSON 时才使用模块中的默认规则。初始化在 Home Manager 的 `writeBoundary` 之后、`linkGeneration` 之前执行，后续激活不覆盖用户修改。不要恢复成单个 JSON 的 Nix store 链接，也不要强制覆盖现有目录或备份。
 
 桌面应用（Firefox、Kitty 等）的启用开关统一放在 `desktop'.apps.<app>.enable`，由 `modules/nixos/desktop/` 下的应用模块定义，模块内部通过 `hm'` 设置 Home Manager 的原生选项。不要为单个用户应用在 Home Manager 里新建自定义命名空间。
 

--- a/Justfile
+++ b/Justfile
@@ -4,11 +4,12 @@ hostname := `hostname -s`
 default:
     @just --list
 
-# Check Nix formatting and unused declarations
+# Check formatting, unused declarations, and all host configurations locally
 check:
     @alejandra --check .
     @deadnix --fail .
     @nix flake check path:. --no-build --all-systems
+    @nix eval path:.#darwinConfigurations --json --apply 'builtins.mapAttrs (_: host: host.system.drvPath)' >/dev/null
 
 # Build and activate the nix-darwin configuration
 [macos]

--- a/docs/NixOS 安装指南.md
+++ b/docs/NixOS 安装指南.md
@@ -158,8 +158,8 @@ lsblk -f
 克隆仓库并进入仓库根目录：
 
 ```bash
-git clone https://github.com/27Aaron/Dotfiles.git ~/Dotfiles
-cd ~/Dotfiles
+git clone https://github.com/27Aaron/Dotfiles.git ~/nix-config
+cd ~/nix-config
 ```
 
 生成不包含文件系统定义的硬件配置：

--- a/docs/macOS 配置指南.md
+++ b/docs/macOS 配置指南.md
@@ -91,10 +91,12 @@ sudo nix run nix-darwin/master#darwin-rebuild -- \
 
 ```bash
 just switch  # 构建并应用当前主机配置
-just check   # 检查格式、未使用声明和 Flake 求值
+just check   # 检查格式、未使用声明、NixOS 和 Darwin 配置求值
 just update  # 更新 flake.lock
 just gc      # 清理 7 天前的旧 generation 及无引用 Store 路径
 ```
+
+CI 只检查格式、未使用声明和 Nix 语法。更新配置或依赖后，请在本地运行 `just check`，通过后再执行 `just switch`。
 
 新增的 `.nix` 文件会由入口模块自动发现。常用配置目录如下：
 
@@ -102,6 +104,22 @@ just gc      # 清理 7 天前的旧 generation 及无引用 Store 路径
 - `home/darwin/`：macOS 专用 Home Manager 配置
 - `modules/common/`：跨平台系统模块
 - `modules/darwin/`：nix-darwin 系统模块
+
+### 编辑 Karabiner 配置
+
+启用 Homebrew 并安装清单中的 `karabiner-elements` 后，首次应用配置会将已有的 Karabiner 配置复制到 `~/.local/share/karabiner/config`，并把 `~/.config/karabiner` 整个目录链接过去。没有已有配置时才使用仓库提供的初始键位。
+
+迁移后，可以在 Karabiner 设置界面修改，或直接编辑 `~/.config/karabiner/karabiner.json`。这些改动保存在可写目录里，不会被后续 `just switch` 覆盖，也不会自动写回 Git 仓库；请把该目录纳入个人备份。
+
+已有的普通配置目录由 Home Manager 备份为 `~/.config/karabiner.hm-bak`。如果同名备份已经存在，激活会停止，请先检查并自行保留该备份，不要直接覆盖它。
+
+首次迁移并启动 Karabiner 后，执行一次以下命令，让它重新监听配置目录；后续编辑无需重复执行：
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/org.pqrs.service.agent.karabiner_console_user_server"
+```
+
+如果提示找不到服务，先启动 Karabiner-Elements 再重试。目录链接与重启要求见 [Karabiner 官方说明](https://karabiner-elements.pqrs.org/docs/manual/misc/configuration-file-path/)。
 
 ## 参考资料
 

--- a/home/common/misc.nix
+++ b/home/common/misc.nix
@@ -40,8 +40,15 @@
     nload
   ]);
 
-  # AI assistants
+  # State for the tools installed above.
   persist'.directories = [
+    # GitHub CLI account settings and fallback credentials.
+    {
+      directory = ".config/gh";
+      mode = "0700";
+    }
+
+    # AI assistants
     ".codex"
     ".claude"
   ];

--- a/home/darwin/apps/karabiner.nix
+++ b/home/darwin/apps/karabiner.nix
@@ -1,86 +1,132 @@
 {
+  config,
   lib,
   osConfig,
+  pkgs,
   ...
 }: let
   brewCfg = osConfig.apps'.homebrew;
   enabled = brewCfg.enable && lib.elem "karabiner-elements" brewCfg.casks;
-in {
-  config = lib.mkIf enabled {
-    home.file.".config/karabiner/karabiner.json".text = builtins.toJSON {
-      profiles = [
-        {
-          complex_modifications = {
-            rules = [
-              {
-                description = "Change right_command key to command+control+option+shift. (Post f19 key when pressed alone)";
-                manipulators = [
-                  {
-                    from = {
-                      key_code = "right_command";
-                      modifiers.optional = ["any"];
-                    };
-                    to = [
-                      {
-                        key_code = "left_shift";
-                        modifiers = [
-                          "left_command"
-                          "left_control"
-                          "left_option"
-                        ];
-                      }
-                    ];
-                    to_if_alone = [
-                      {
-                        key_code = "f19";
-                      }
-                    ];
-                    type = "basic";
-                  }
-                ];
-              }
-              {
-                description = "Click Control => Capslock , Long press Control => Control";
-                manipulators = [
-                  {
-                    from = {
-                      key_code = "left_control";
-                      modifiers.optional = ["any"];
-                    };
-                    to = [
-                      {
-                        key_code = "left_control";
-                      }
-                    ];
-                    to_if_alone = [
-                      {
-                        hold_down_milliseconds = 100;
-                        key_code = "caps_lock";
-                      }
-                    ];
-                    type = "basic";
-                  }
-                ];
-              }
-            ];
-          };
-          devices = [
+  writableDir = "${config.xdg.dataHome}/karabiner/config";
+
+  # Only used when neither an existing configuration nor a writable copy exists.
+  initialConfig = builtins.toFile "karabiner-initial.json" (builtins.toJSON {
+    profiles = [
+      {
+        complex_modifications = {
+          rules = [
             {
-              disable_built_in_keyboard_if_exists = true;
-              identifiers = {
-                is_keyboard = true;
-                product_id = 33;
-                vendor_id = 1278;
-              };
+              description = "Change right_command key to command+control+option+shift. (Post f19 key when pressed alone)";
+              manipulators = [
+                {
+                  from = {
+                    key_code = "right_command";
+                    modifiers.optional = ["any"];
+                  };
+                  to = [
+                    {
+                      key_code = "left_shift";
+                      modifiers = [
+                        "left_command"
+                        "left_control"
+                        "left_option"
+                      ];
+                    }
+                  ];
+                  to_if_alone = [
+                    {
+                      key_code = "f19";
+                    }
+                  ];
+                  type = "basic";
+                }
+              ];
+            }
+            {
+              description = "Click Control => Capslock , Long press Control => Control";
+              manipulators = [
+                {
+                  from = {
+                    key_code = "left_control";
+                    modifiers.optional = ["any"];
+                  };
+                  to = [
+                    {
+                      key_code = "left_control";
+                    }
+                  ];
+                  to_if_alone = [
+                    {
+                      hold_down_milliseconds = 100;
+                      key_code = "caps_lock";
+                    }
+                  ];
+                  type = "basic";
+                }
+              ];
             }
           ];
-          name = "Default profile";
-          selected = true;
-          virtual_hid_keyboard = {
-            keyboard_type_v2 = "ansi";
-          };
-        }
-      ];
-    };
+        };
+        devices = [
+          {
+            disable_built_in_keyboard_if_exists = true;
+            identifiers = {
+              is_keyboard = true;
+              product_id = 33;
+              vendor_id = 1278;
+            };
+          }
+        ];
+        name = "Default profile";
+        selected = true;
+        virtual_hid_keyboard = {
+          keyboard_type_v2 = "ansi";
+        };
+      }
+    ];
+  });
+in {
+  config = lib.mkIf enabled {
+    # Karabiner watches the directory; its JSON must remain a writable file.
+    xdg.configFile."karabiner".source = config.lib.file.mkOutOfStoreSymlink writableDir;
+
+    home.activation.initializeKarabiner = lib.hm.dag.entryBetween ["linkGeneration"] ["writeBoundary"] ''
+      initializeKarabinerConfig() (
+        set -e
+        export PATH="${lib.makeBinPath [pkgs.coreutils]}:$PATH"
+        umask 077
+        current=$1
+        target=$2
+        seed=$3
+
+        if [[ -e "$target" || -L "$target" ]]; then
+          if [[ ! -d "$target" ]]; then
+            echo "Karabiner configuration target is not a directory: $target" >&2
+            exit 1
+          fi
+          exit 0
+        fi
+
+        mkdir -p -- "$(dirname "$target")"
+        staging="$(mktemp -d "$target.XXXXXX")"
+        trap 'rm -rf -- "$staging"' EXIT
+
+        if [[ -d "$current" ]]; then
+          cp -RL --no-preserve=mode -- "$current/." "$staging/"
+        fi
+        if [[ ! -f "$staging/karabiner.json" ]]; then
+          cp -- "$seed" "$staging/karabiner.json"
+        fi
+
+        chmod -R u+rwX -- "$staging"
+        mv -T --no-clobber -- "$staging" "$target"
+      )
+
+      run initializeKarabinerConfig \
+        ${lib.escapeShellArg "${config.xdg.configHome}/karabiner"} \
+        ${lib.escapeShellArg writableDir} \
+        ${lib.escapeShellArg initialConfig}
+      unset -f initializeKarabinerConfig
+    '';
   };
 }

--- a/modules/nixos/apps/postgresql.nix
+++ b/modules/nixos/apps/postgresql.nix
@@ -18,9 +18,9 @@ in {
     };
 
     dataDir = lib.mkOption {
-      type = lib.types.str;
+      type = lib.types.path;
       default = "/var/lib/postgresql";
-      description = "Directory in which PostgreSQL stores its data";
+      description = "PostgreSQL data directory; changing the major version requires an explicit data migration";
     };
 
     port = lib.mkOption {
@@ -89,6 +89,13 @@ in {
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [cfg.port];
 
-    preservation'.os.directories = [cfg.dataDir];
+    preservation'.os.directories = [
+      {
+        directory = cfg.dataDir;
+        user = "postgres";
+        group = "postgres";
+        mode = "0750";
+      }
+    ];
   };
 }

--- a/modules/nixos/storage/persistence.nix
+++ b/modules/nixos/storage/persistence.nix
@@ -53,11 +53,13 @@ in {
         ".local/state/home-manager"
         ".local/state/nix/profiles"
 
-        # Credentials without a managing module live here.
+        # The configuration checkout used by nh.
         {
           directory = "nix-config";
           mode = "0700";
         }
+
+        # Credentials without a managing module live here.
         {
           directory = ".ssh";
           mode = "0700";

--- a/modules/nixos/system/nix.nix
+++ b/modules/nixos/system/nix.nix
@@ -18,6 +18,6 @@ in {
 
   programs.nh = {
     enable = true;
-    flake = lib.mkDefault "/home/${user}/Dotfiles";
+    flake = lib.mkDefault "/home/${user}/nix-config";
   };
 }


### PR DESCRIPTION
## 改动

- 将 NixOS 的 `nh` 默认仓库路径修正为 `~/nix-config`，与现有持久化目录一致，并同步安装文档。
- 为 GitHub CLI 的 `.config/gh` 添加持久化，权限为 `0700`。
- 为 PostgreSQL 的持久化目录明确设置 `postgres:postgres` 和 `0750`，目录创建交给 Preservation；保留 `/var/lib/postgresql` 固定默认路径，以及原有认证、用户映射和日志设置，不增加独立 tmpfiles 规则。
- 将 Karabiner 改为整个配置目录的可写链接。首次初始化保留已有 JSON 和 assets，没有旧配置时才使用默认键位；后续激活不覆盖手动或 GUI 修改。
- CI 保留格式、deadnix 和 Nix 语法检查，移除 Flake 求值；本地 `just check` 保留完整求值并显式检查 Darwin 配置。
- 更新 Karabiner 使用说明和仓库约定。Homebrew `zap`、Niri 和现有快照配置保持不变。

## 验证

- `just check`：Alejandra、deadnix、全平台 Flake 求值及 Darwin 显式求值通过。
- 66 个 Nix 文件的 `nix-instantiate --parse` 检查通过。
- Karabiner 在临时目录中的 8 项测试通过，覆盖首次初始化、旧配置迁移、重复执行保留编辑、目录链接写入、dry-run 和失败时不覆盖原数据。
- PostgreSQL 的 12 组配置求值检查通过，核对目录路径、Preservation 创建规则与权限，以及原认证和日志设置未变；当前两台主机仍未启用数据库。
- `nh`、GH 持久化、Karabiner 的 Homebrew 启用条件及 `zap` 保留的集成断言通过。
- `git diff --check` 通过。

## 应用注意事项

- 本次未切换系统、启动数据库或修改正在使用的 Karabiner 配置；验证不包含 NixOS 实机启动。
- Karabiner 首次迁移后需按 macOS 指南重启一次配置监听服务。后续修改保存在 `~/.local/share/karabiner/config`，不会自动写回 Git；已有同名 `.hm-bak` 备份会阻止覆盖。
- PostgreSQL 目录创建依赖启用的 Preservation；关闭持久化时需要另外准备数据目录及权限。大版本升级仍需显式迁移数据库。
