### PR TITLE
refactor(nixos): 整理主机与硬件配置

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Justfile              switch / check / update / gc / fmt 等常用命令
 - 每台主机注入同一组 `specialArgs`：`inputs`、`myvars`、`hostName`、`platformName`；Home Manager 通过 `extraSpecialArgs` 收到同一组，并以 `backupFileExtension = "hm-bak"` 接入主用户。模块和 Home Manager 文件可以直接取用这些参数。
 - `modules/default.nix` 递归扫描 `modules/common/` 和当前平台目录：含 `default.nix` 的目录作为单个模块整体导入，否则继续下钻；普通 `.nix` 文件直接导入。新增模块放入正确的职责目录即可，无需登记。
 - `home/default.nix` 递归导入 `home/common/` 和平台目录下的所有 `.nix` 文件。
-- NixOS 主机的 `hardware.nix` 持有硬件探测结果、内核、引导和 `storage'.disko` 磁盘参数（`device`、`espSize`、`swapSize`、`luks.enable`）。
+- NixOS 主机的 `default.nix` 按 `imports`、`services'`、`desktop'`、安全配置（`security` / `security'`）、`system.stateVersion` 的顺序组织，分组内按名称排序。
+- NixOS 主机的 `hardware.nix` 持有硬件探测结果、`hardware'` 硬件支持开关、内核、引导与主机级存储配置：`storage'.disko` 磁盘参数（`device`、`espSize`、`swapSize`、`luks.enable`）和 `storage'.persistence.enable`。功能所属的持久化文件和目录清单仍由各自模块声明。
 
 ## 模块和命名约定
 

--- a/docs/NixOS 安装指南.md
+++ b/docs/NixOS 安装指南.md
@@ -168,7 +168,7 @@ cd ~/nix-config
 sudo nixos-generate-config --no-filesystems --root /mnt
 ```
 
-检查 `/mnt/etc/nixos/hardware-configuration.nix`，将仍然需要的硬件探测结果合并到 `hosts/nixos/elaina/hardware.nix`，不要覆盖已有的 Disko 和引导配置。
+检查 `/mnt/etc/nixos/hardware-configuration.nix`，将仍然需要的硬件探测结果合并到 `hosts/nixos/elaina/hardware.nix`，不要覆盖已有的 Disko、持久化和引导配置。
 
 确认 `vars/default.nix` 中的用户名、密码哈希、SSH 公钥和默认时区，以及 `hosts/nixos/<主机名>/default.nix` 中的系统状态版本正确，然后安装系统：
 

--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -1,8 +1,4 @@
 {...}: {
-  system.stateVersion = "26.11";
-
-  storage'.persistence.enable = true;
-
   imports = [
     ./hardware.nix
   ];
@@ -15,4 +11,6 @@
   };
 
   security'.firewall.enable = true;
+
+  system.stateVersion = "26.11";
 }

--- a/hosts/nixos/beelink/hardware.nix
+++ b/hosts/nixos/beelink/hardware.nix
@@ -2,34 +2,44 @@
   config,
   inputs,
   lib,
-  pkgs,
   modulesPath,
+  pkgs,
   ...
 }: {
   imports = [
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
-  boot.initrd.availableKernelModules = ["nvme" "xhci_pci" "thunderbolt" "usbhid" "usb_storage" "sd_mod"];
-  boot.initrd.kernelModules = [];
-  boot.kernelModules = ["kvm-amd"];
-  boot.extraModulePackages = [];
-  boot.kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest-lto-x86_64-v3;
-
-  nixpkgs.overlays = [inputs.nix-cachyos-kernel.overlays.pinned];
-
-  boot.loader = {
-    systemd-boot.enable = true;
-    efi.canTouchEfiVariables = true;
+  nixpkgs = {
+    hostPlatform = lib.mkDefault "x86_64-linux";
+    overlays = [inputs.nix-cachyos-kernel.overlays.pinned];
   };
 
-  storage'.disko = {
-    enable = true;
-    device = "/dev/nvme0n1";
-    espSize = "1G";
-    luks.enable = true;
+  boot = {
+    initrd = {
+      availableKernelModules = ["nvme" "xhci_pci" "thunderbolt" "usbhid" "usb_storage" "sd_mod"];
+      kernelModules = [];
+    };
+
+    kernelModules = ["kvm-amd"];
+    extraModulePackages = [];
+    kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest-lto-x86_64-v3;
+
+    loader = {
+      systemd-boot.enable = true;
+      efi.canTouchEfiVariables = true;
+    };
   };
 
-  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  storage' = {
+    disko = {
+      enable = true;
+      device = "/dev/nvme0n1";
+      espSize = "1G";
+      luks.enable = true;
+    };
+    persistence.enable = true;
+  };
 }

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -1,11 +1,19 @@
 {...}: {
-  system.stateVersion = "26.11";
-
-  storage'.persistence.enable = true;
-
   imports = [
     ./hardware.nix
   ];
+
+  services' = {
+    btrbk.enable = true;
+    btrfs-scrub.enable = true;
+    networkmanager.enable = true;
+    openssh.enable = true;
+    printing.enable = true;
+    smartd.enable = true;
+    upower.enable = true;
+    vnstat.enable = true;
+    zram.enable = true;
+  };
 
   desktop' = {
     applications.enable = true;
@@ -24,24 +32,8 @@
     themes.enable = true;
   };
 
-  hardware' = {
-    amdgpu.enable = true;
-    bluetooth.enable = true;
-  };
-
   security.rtkit.enable = true;
-
-  services' = {
-    btrbk.enable = true;
-    btrfs-scrub.enable = true;
-    networkmanager.enable = true;
-    openssh.enable = true;
-    printing.enable = true;
-    smartd.enable = true;
-    upower.enable = true;
-    vnstat.enable = true;
-    zram.enable = true;
-  };
-
   security'.firewall.enable = true;
+
+  system.stateVersion = "26.11";
 }

--- a/hosts/nixos/elaina/hardware.nix
+++ b/hosts/nixos/elaina/hardware.nix
@@ -2,35 +2,50 @@
   config,
   inputs,
   lib,
-  pkgs,
   modulesPath,
+  pkgs,
   ...
 }: {
   imports = [
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
-  boot.initrd.availableKernelModules = ["nvme" "sd_mod" "thunderbolt" "usb_storage" "xhci_pci"];
-  boot.initrd.kernelModules = [];
-  boot.kernelModules = ["kvm-amd"];
-  boot.extraModulePackages = [];
-  boot.kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest-lto-zen4;
-
-  nixpkgs.overlays = [inputs.nix-cachyos-kernel.overlays.pinned];
-
-  boot.loader = {
-    systemd-boot.enable = true;
-    efi.canTouchEfiVariables = true;
+  nixpkgs = {
+    hostPlatform = lib.mkDefault "x86_64-linux";
+    overlays = [inputs.nix-cachyos-kernel.overlays.pinned];
   };
 
-  storage'.disko = {
-    enable = true;
-    device = "/dev/nvme0n1";
-    espSize = "1G";
-    swapSize = "32769M";
-    luks.enable = true;
+  boot = {
+    initrd = {
+      availableKernelModules = ["nvme" "sd_mod" "thunderbolt" "usb_storage" "xhci_pci"];
+      kernelModules = [];
+    };
+
+    kernelModules = ["kvm-amd"];
+    extraModulePackages = [];
+    kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest-lto-zen4;
+
+    loader = {
+      systemd-boot.enable = true;
+      efi.canTouchEfiVariables = true;
+    };
   };
 
-  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  hardware' = {
+    amdgpu.enable = true;
+    bluetooth.enable = true;
+  };
+
+  storage' = {
+    disko = {
+      enable = true;
+      device = "/dev/nvme0n1";
+      espSize = "1G";
+      swapSize = "32769M";
+      luks.enable = true;
+    };
+    persistence.enable = true;
+  };
 }


### PR DESCRIPTION
## 背景与目的

此前两台 NixOS 主机的持久化总开关放在主机入口中，而 Disko、引导与内核配置放在硬件文件中；Elaina 的硬件支持开关也分散在入口文件。硬件文件里的 `boot` 与 `nixpkgs` 属性多处重复前缀，相关设置不够集中。

本 PR 按职责整理这些配置，并统一为便于维护的 Nix 属性集写法。目标是改善文件分工和可读性，不改变系统配置结果。

## 主要改动

- 将 Beelink、Elaina 的 `storage'.persistence.enable` 移入各自的 `hardware.nix`，与原有 Disko 配置归入同一 `storage'` 分组。迁移的是主机级开关，不是持久化文件或目录清单。
- 将 Elaina 的 AMDGPU、Bluetooth 开关移入其硬件文件；不为 Beelink 增加这些功能。
- 将硬件文件中分散的启动设置合并为 `boot = { ... };`，内部集中组织 `initrd`、内核与 `loader`；将平台及 overlay 设置合并为 `nixpkgs = { ... };`。
- 主机入口按“导入 → 服务 → 桌面（如适用）→ 安全 → 系统状态版本”组织，保留现有服务与桌面应用开关。
- 同步 `AGENTS.md` 中的主机文件职责和排序约定；安装指南增加合并硬件探测结果时不要覆盖持久化配置的提醒。没有加入关于 PR 负责人、标签或描述的长期规则。

## 影响范围与兼容性

- 修改范围为 `hosts/nixos/beelink/`、`hosts/nixos/elaina/` 下的四个主机文件及两份相关文档。
- 不修改公共功能模块、Home Manager 配置、Darwin 主机或 `flake.lock`。
- 内核选择、内核模块列表及其顺序、磁盘设备、分区参数、LUKS、Elaina 的交换空间、`mkDefault` 和 `system.stateVersion` 均保持原值。
- 服务、桌面应用和硬件支持的启用状态不变；各功能模块仍负责自己的持久化条目，不改变持久化路径或数据布局。

## 验证结果

以下检查已在本地执行通过：

- `git diff --cached --check`：暂存内容无空白错误。
- `alejandra --check .`：格式检查通过。
- `deadnix --fail .`：未使用声明检查通过。
- 对 `rg --files -g '*.nix'` 列出的每个文件执行 `nix-instantiate --parse`：全部通过。
- `nix flake check --offline --no-write-lock-file --no-build --all-systems path:.`：flake 全系统检查通过，包括两台 NixOS 主机求值。
- `nix eval --offline --no-write-lock-file --json path:.#nixosConfigurations --apply 'builtins.mapAttrs (_: host: host.config.system.build.toplevel.drvPath)'`：两台 NixOS 主机的系统派生路径与整理前记录完全一致。
- `nix eval --offline --no-write-lock-file --json path:.#darwinConfigurations --apply 'builtins.mapAttrs (_: host: host.system.drvPath)'`：Darwin 主机求值通过。

另对整理前后的主机配置做了独立静态复核：合并入口和硬件模块后，Beelink 的 21 个、Elaina 的 42 个属性表达式均保持一致。

以上是静态检查和求值验证，不代表已完成 Linux 系统构建或真机运行测试。本次没有构建、激活或重启任何设备。

## 风险与后续操作

这是结构性整理，已核对系统派生结果不变。合并后正常同步配置即可，不需要数据迁移，也不需要重新分区或格式化磁盘。

如需回退，恢复本 PR 之前的配置即可；由于没有改变磁盘或持久化数据布局，无需额外的数据回迁。
