### PR TITLE
feat(nixos): 新增 Coder 服务端模块并在 beelink 启用

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -4,6 +4,14 @@
   ];
 
   services' = {
+    coder = {
+      enable = true;
+      listenAddress = "0.0.0.0:34567";
+      accessUrl = "https://coder.in.ou.al";
+      wildcardAccessUrl = "https://*.coder.in.ou.al";
+      openFirewall = true;
+    };
+    postgresql.enable = true;
     networkmanager.enable = true;
     openssh.enable = true;
     vnstat.enable = true;

--- a/modules/nixos/apps/coder.nix
+++ b/modules/nixos/apps/coder.nix
@@ -1,0 +1,136 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.services'.coder;
+
+  # The upstream option is a "host:port" string, including IPv6 forms like
+  # "[::]:3000"; the port is always the segment after the last colon.
+  listenPort = lib.toInt (lib.last (lib.splitString ":" cfg.listenAddress));
+
+  loopbackListen =
+    lib.hasPrefix "127." cfg.listenAddress
+    || lib.hasPrefix "localhost" cfg.listenAddress
+    || lib.hasPrefix "[::1]" cfg.listenAddress;
+in {
+  options.services'.coder = {
+    enable = lib.mkEnableOption "Enable Coder server";
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1:3000";
+      description = "Address and port the Coder server listens on; use 0.0.0.0:3000 for direct LAN access";
+    };
+
+    accessUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "https://coder.example.com";
+      description = "External URL users use to reach Coder; required for workspace apps and port forwarding";
+    };
+
+    wildcardAccessUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "*.coder.example.com";
+      description = "Wildcard domain serving workspace apps";
+    };
+
+    database = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Use the local PostgreSQL managed by services'.postgresql; set false together with host below for a remote one";
+      };
+
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "/run/postgresql";
+        description = "PostgreSQL host; a value starting with / is a Unix socket directory";
+      };
+
+      database = lib.mkOption {
+        type = lib.types.str;
+        default = "coder";
+        description = "PostgreSQL database name";
+      };
+
+      username = lib.mkOption {
+        type = lib.types.str;
+        default = "coder";
+        description = "PostgreSQL user; must stay coder while createLocally is enabled";
+      };
+
+      password = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "PostgreSQL password; ends up in the systemd unit environment in plaintext because the upstream module always sets the connection URL directly";
+      };
+
+      sslmode = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = "disable";
+        example = "require";
+        description = "PostgreSQL SSL mode; use require or stricter when connecting over TCP to a remote database";
+      };
+    };
+
+    openFirewall = lib.mkEnableOption "Open firewall port for Coder";
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Low-priority passthrough so hosts can still set the underlying
+    # services.coder options directly without merge conflicts.
+    services.coder = {
+      enable = true;
+      listenAddress = lib.mkDefault cfg.listenAddress;
+      accessUrl = lib.mkDefault cfg.accessUrl;
+      wildcardAccessUrl = lib.mkDefault cfg.wildcardAccessUrl;
+
+      database = {
+        createLocally = lib.mkDefault cfg.database.createLocally;
+        host = lib.mkDefault cfg.database.host;
+        database = lib.mkDefault cfg.database.database;
+        username = lib.mkDefault cfg.database.username;
+        password = lib.mkDefault cfg.database.password;
+        sslmode = lib.mkDefault cfg.database.sslmode;
+      };
+    };
+
+    # Catch a crash-looping misconfiguration at eval time: with the local
+    # database, the socket directory is fixed by the PostgreSQL module.
+    assertions = [
+      {
+        assertion = cfg.database.createLocally -> cfg.database.host == "/run/postgresql";
+        message = "services'.coder.database.host must stay \"/run/postgresql\" while createLocally is enabled";
+      }
+    ];
+
+    warnings =
+      lib.optional
+      (cfg.openFirewall && loopbackListen)
+      "services'.coder.openFirewall is set but listenAddress ${cfg.listenAddress} is loopback-only; external clients still cannot reach Coder";
+
+    # Reuse the repo's PostgreSQL module so its tuning, authentication map
+    # and /var/lib/postgresql persistence apply whenever Coder needs a local
+    # database. Hosts can still override it.
+    services'.postgresql.enable = lib.mkDefault cfg.database.createLocally;
+
+    # The upstream unit only orders after network.target, which races with
+    # PostgreSQL init on first boot.
+    systemd.services.coder.after = lib.mkIf cfg.database.createLocally ["postgresql.service"];
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [listenPort];
+
+    # Upstream user/group/homeDir must stay at their defaults ("coder",
+    # /var/lib/coder) for this ownership and directory to match.
+    preservation'.os.directories = [
+      {
+        directory = "/var/lib/coder";
+        user = "coder";
+        group = "coder";
+      }
+    ];
+  };
+}


### PR DESCRIPTION
## 改动内容

- **新增模块 `modules/nixos/apps/coder.nix`**，把上游的 `services.coder` 包装在 `services'.coder` 之下：
  - 以低优先级（`mkDefault`）透传监听地址、访问 URL 和数据库选项，主机仍可直接设置原生 `services.coder.*` 选项而不产生合并冲突。
  - 当 `database.createLocally` 开启时，通过 `mkDefault` 引入仓库的 PostgreSQL 模块（调优、peer 认证、`/var/lib/postgresql` 持久化），让服务单元排在 `postgresql.service` 之后，并持久化 `/var/lib/coder`。
  - 求值期断言：`createLocally` 开启时 `database.host` 必须保持在本地 socket（避免运行时陷入崩溃循环）。
  - 警告：`openFirewall` 与回环地址 `listenAddress` 组合时触发。
- **beelink**：以 `openFirewall` 在 `0.0.0.0:34567` 上启用 Coder，经局域网反向代理对外提供 `https://coder.in.ou.al`，workspace 应用使用 `https://*.coder.in.ou.al`；主机上显式启用 PostgreSQL。

## 验证

- `alejandra .`、`deadnix --fail .`、对全部 `.nix` 文件做语法解析检查
- `nix flake check --no-build`（求值所有主机，在临时非 Git 副本中运行）
- 启用态求值：顶层 derivation 可构建、PostgreSQL 关联、防火墙端口解析、单元排序、持久化条目、警告与断言行为均验证通过
