### PR TITLE
feat(nixos): 新增 PVE router 虚拟机主机

### DIFF
--- a/docs/disko.nix
+++ b/docs/disko.nix
@@ -1,0 +1,90 @@
+{...}: {
+  disko.devices = {
+    nodev."/" = {
+      fsType = "tmpfs";
+      mountOptions = [
+        "mode=755"
+        "nodev"
+        "nosuid"
+        "relatime"
+        "size=512M"
+      ];
+    };
+
+    disk.main = {
+      type = "disk";
+      device = "/dev/sda";
+
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            priority = 1;
+            size = "256M";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              extraArgs = [
+                "-n"
+                "BOOT"
+              ];
+              mountOptions = ["umask=0077"];
+            };
+          };
+
+          root = {
+            priority = 2;
+            size = "100%";
+            type = "8300";
+            content = {
+              type = "btrfs";
+              extraArgs = [
+                "-f"
+                "--csum"
+                "xxhash64"
+                "--label"
+                "NixOS"
+              ];
+              mountpoint = "/btr_pool";
+              mountOptions = [
+                "noatime"
+                "subvolid=5"
+              ];
+
+              subvolumes = {
+                "@nix" = {
+                  mountpoint = "/nix";
+                  mountOptions = [
+                    "compress=zstd:1"
+                    "discard=async"
+                    "noatime"
+                  ];
+                };
+
+                "@persistent" = {
+                  mountpoint = "/persistent";
+                  mountOptions = [
+                    "compress=zstd:1"
+                    "discard=async"
+                    "noatime"
+                  ];
+                };
+
+                "@snapshots" = {
+                  mountpoint = "/snapshots";
+                  mountOptions = [
+                    "compress=zstd:1"
+                    "discard=async"
+                    "noatime"
+                  ];
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/hosts/nixos/router/default.nix
+++ b/hosts/nixos/router/default.nix
@@ -1,0 +1,16 @@
+{...}: {
+  imports = [
+    ./hardware.nix
+  ];
+
+  services' = {
+    btrfs-scrub.enable = true;
+    openssh.enable = true;
+    vnstat.enable = true;
+    zram.enable = true;
+  };
+
+  security'.firewall.enable = true;
+
+  system.stateVersion = "26.11";
+}

--- a/hosts/nixos/router/hardware.nix
+++ b/hosts/nixos/router/hardware.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  modulesPath,
+  ...
+}: {
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+  ];
+
+  boot = {
+    initrd.availableKernelModules = ["uhci_hcd" "ehci_pci" "ahci" "virtio_pci" "virtio_scsi" "sd_mod" "sr_mod"];
+    initrd.kernelModules = [];
+    # The system runs as a PVE guest and does not host KVM guests itself.
+    kernelModules = [];
+    extraModulePackages = [];
+
+    loader = {
+      systemd-boot.enable = true;
+      efi.canTouchEfiVariables = true;
+    };
+  };
+
+  # PVE uses the guest agent for clean shutdown and IP reporting.
+  services.qemuGuest.enable = true;
+
+  # Headless VM: systemd-networkd instead of NetworkManager.
+  networking = {
+    useNetworkd = true;
+    useDHCP = false;
+  };
+
+  systemd.network.networks."10-ether" = {
+    matchConfig.Type = "ether";
+    networkConfig.DHCP = "yes";
+  };
+
+  services.resolved.enable = true;
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+
+  # Matches the layout in docs/disko.nix.
+  storage' = {
+    disko = {
+      enable = true;
+      device = "/dev/sda";
+      tmpfsSize = "512M";
+    };
+    persistence.enable = true;
+  };
+}

--- a/modules/nixos/storage/disko.nix
+++ b/modules/nixos/storage/disko.nix
@@ -53,6 +53,13 @@ in {
       description = "Disk device path";
     };
 
+    tmpfsSize = lib.mkOption {
+      type = lib.types.str;
+      default = "4G";
+      example = "512M";
+      description = "Tmpfs root size";
+    };
+
     espSize = lib.mkOption {
       type = lib.types.str;
       default = "256M";
@@ -79,7 +86,7 @@ in {
           "nodev"
           "nosuid"
           "relatime"
-          "size=4G"
+          "size=${cfg.tmpfsSize}"
         ];
       };
 


### PR DESCRIPTION
为 PVE router 虚拟机新增一台 NixOS 主机，使用保存在 `docs/disko.nix` 的不加密、无 swap 磁盘布局（tmpfs 根、ESP、btrfs `@nix` / `@persistent` / `@snapshots`）。

- 为主机接入 `storage'.disko` 与 `storage'.persistence`，并启用 systemd-boot
- 无头客户机改用 systemd-networkd + resolved 替代 NetworkManager（DHCP 按链路类型匹配，而非接口名）
- 启用 qemu-guest-agent，支持 PVE 优雅关机与 IP 上报
- 移除无用的 `kvm-intel` 内核模块（客户机不承载虚拟机）
- 启用每月一次的 btrfs scrub
- 为 `storage'.disko` 新增 `tmpfsSize` 选项（默认值仍为 `4G`），使临时根分区可匹配 `docs/disko.nix` 中 512M 的布局
