### PR TITLE
feat(nixos): 使用 systemd-networkd 为 router 配置静态 IP

### DIFF
--- a/hosts/nixos/router/default.nix
+++ b/hosts/nixos/router/default.nix
@@ -1,10 +1,10 @@
 {...}: {
   imports = [
+    ./network.nix
     ./hardware.nix
   ];
 
   services' = {
-    btrfs-scrub.enable = true;
     openssh.enable = true;
     vnstat.enable = true;
     zram.enable = true;

--- a/hosts/nixos/router/hardware.nix
+++ b/hosts/nixos/router/hardware.nix
@@ -8,6 +8,11 @@
   ];
 
   boot = {
+    # Classic interface naming: the NIC shows up as eth0 instead of a
+    # predictable name like ens18. audit=0 turns off the kernel audit
+    # subsystem, whose event log is noise on a home router VM.
+    kernelParams = ["audit=0" "net.ifnames=0"];
+
     initrd.availableKernelModules = ["uhci_hcd" "ehci_pci" "ahci" "virtio_pci" "virtio_scsi" "sd_mod" "sr_mod"];
     initrd.kernelModules = [];
     # The system runs as a PVE guest and does not host KVM guests itself.
@@ -22,19 +27,6 @@
 
   # PVE uses the guest agent for clean shutdown and IP reporting.
   services.qemuGuest.enable = true;
-
-  # Headless VM: systemd-networkd instead of NetworkManager.
-  networking = {
-    useNetworkd = true;
-    useDHCP = false;
-  };
-
-  systemd.network.networks."10-ether" = {
-    matchConfig.Type = "ether";
-    networkConfig.DHCP = "yes";
-  };
-
-  services.resolved.enable = true;
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 

--- a/hosts/nixos/router/network.nix
+++ b/hosts/nixos/router/network.nix
@@ -1,0 +1,21 @@
+{...}: {
+  # Headless VM: systemd-networkd instead of NetworkManager.
+  networking = {
+    useNetworkd = true;
+    useDHCP = false;
+  };
+
+  services.resolved.enable = true;
+
+  systemd.network.networks."10-eth0" = {
+    matchConfig.Name = "eth0";
+    networkConfig = {
+      # IPv4 comes from the static address; IPv6 addresses and routes are
+      # obtained through DHCPv6 and router advertisements.
+      Address = "10.77.77.66/24";
+      Gateway = "10.77.77.1";
+      DNS = ["10.77.77.1"];
+      DHCP = "ipv6";
+    };
+  };
+}


### PR DESCRIPTION
把 router 的网络设置从 `hardware.nix` 拆分到独立的 `network.nix`。

- systemd-networkd + resolved，按名称匹配网卡
- 静态 IPv4 `10.77.77.66/24`，网关 `10.77.77.1`，DNS `10.77.77.1`
- `DHCP = "ipv6"`：IPv4 保持纯静态；IPv6 地址与路由经 DHCPv6 和路由通告获取
- `kernelParams`：`net.ifnames=0` 使用传统 `eth0` 命名，`audit=0` 关闭内核审计日志

注意：上游路由通告携带 M/O 标志时 DHCPv6 才会启动；如果 IPv6 地址一直不出现，可在网络配置中添加 `ipv6AcceptRAConfig.DHCPv6Client = "always";`。
