### PR TITLE
refactor: 将 AI CLI 与 ffmpeg 从共享 home 基线中拆分出去

### DIFF
--- a/home/common/misc.nix
+++ b/home/common/misc.nix
@@ -5,8 +5,6 @@
 }: {
   home.packages = lib.mkAfter (with pkgs; [
     # Development
-    codex
-    claude-code
     gh
     just
     lazygit
@@ -24,9 +22,6 @@
     ripgrep
     tree
     wget
-
-    # Media
-    ffmpeg
 
     # Network
     iperf3
@@ -46,17 +41,6 @@
     {
       directory = ".config/gh";
       mode = "0700";
-    }
-
-    # AI assistants
-    ".codex"
-    ".claude"
-  ];
-
-  persist'.files = [
-    {
-      file = ".claude.json";
-      how = "bindmount";
     }
   ];
 }

--- a/home/darwin/ai.nix
+++ b/home/darwin/ai.nix
@@ -1,4 +1,9 @@
-{
+{pkgs, ...}: {
+  home.packages = with pkgs; [
+    claude-code
+    codex
+  ];
+
   home.shellAliases = {
     cc = "claude --dangerously-skip-permissions";
     cx = "codex --dangerously-bypass-approvals-and-sandbox";

--- a/home/darwin/ffmpeg.nix
+++ b/home/darwin/ffmpeg.nix
@@ -1,0 +1,3 @@
+{pkgs, ...}: {
+  home.packages = [pkgs.ffmpeg];
+}

--- a/modules/nixos/desktop/ai-cli.nix
+++ b/modules/nixos/desktop/ai-cli.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.desktop'.apps.ai-cli;
+in {
+  options.desktop'.apps.ai-cli.enable = lib.mkEnableOption "AI coding CLIs (Claude Code and Codex)";
+
+  config = lib.mkIf cfg.enable {
+    hm'.home.packages = with pkgs; [
+      claude-code
+      codex
+    ];
+
+    hm'.home.shellAliases = {
+      cc = "claude --dangerously-skip-permissions";
+      cx = "codex --dangerously-bypass-approvals-and-sandbox";
+    };
+
+    preservation'.user = {
+      directories = [
+        ".claude"
+        ".codex"
+      ];
+
+      files = [
+        {
+          file = ".claude.json";
+          how = "bindmount";
+        }
+      ];
+    };
+  };
+}


### PR DESCRIPTION
- 把 `claude-code` 和 `codex` 从共享的 `home/common/misc.nix` 移入新的 `desktop'.apps.ai-cli` 开关（默认关闭）：软件包、`cc`/`cx` 别名及其状态持久化（`.claude`、`.claude.json`、`.codex`）都收敛到该模块，沿用既有 `desktop'.apps.*` 模式
- macOS 通过 `home/darwin/ai.nix` 无条件保留两个 CLI（平台目录，无需持久化）
- `ffmpeg` 移到 `home/darwin/ffmpeg.nix`（目前只在 macOS 上使用）
- 删除 `home/common/shell.nix`（只承载 AI 别名）

> [!NOTE]
> NixOS 主机默认不再安装 AI CLI——包括 elaina。需要时在主机上设置 `desktop'.apps.ai-cli.enable = true;`。已通过求值验证：router/elaina 没有 `claude-code`/`codex`/`ffmpeg`/别名，luna 保留全部。
