### PR TITLE
feat(darwin): 将 Homebrew 更新改为按需开启

### DIFF
--- a/modules/darwin/apps/homebrew.nix
+++ b/modules/darwin/apps/homebrew.nix
@@ -23,7 +23,7 @@ in {
     onActivation = {
       autoUpdate = lib.mkOption {
         type = lib.types.bool;
-        default = true;
+        default = false;
         description = "Fetch the newest stable Homebrew branch on activation";
       };
 
@@ -35,7 +35,7 @@ in {
 
       upgrade = lib.mkOption {
         type = lib.types.bool;
-        default = true;
+        default = false;
         description = "Upgrade outdated Homebrew packages on activation";
       };
     };


### PR DESCRIPTION
## 摘要

- nix-darwin 激活期间不再执行 Homebrew 元数据更新
- 激活期间不再自动升级软件包
- 保留既有的 zap 清理策略
- 手动 `brew update` 和 `brew upgrade` 流程保持不变

## 测试

- alejandra
- deadnix
- Nix 语法检查
- 完整 flake 求值
