### PR TITLE
fix(nixos): 加固 PostgreSQL 与 Coder 的集成

### DIFF
--- a/modules/nixos/apps/coder.nix
+++ b/modules/nixos/apps/coder.nix
@@ -108,6 +108,10 @@ in {
         message = "services'.coder.database.host must stay \"/run/postgresql\" while createLocally is enabled";
       }
       {
+        assertion = !cfg.database.createLocally || config.services'.postgresql.enable;
+        message = "services'.postgresql.enable must be true while services'.coder.database.createLocally is enabled";
+      }
+      {
         assertion =
           cfg.wildcardAccessUrl
           == null
@@ -122,13 +126,14 @@ in {
       "services'.coder.openFirewall is set but listenAddress ${cfg.listenAddress} is loopback-only; external clients still cannot reach Coder";
 
     # Reuse the repo's PostgreSQL module so its tuning, authentication map
-    # and /var/lib/postgresql persistence apply whenever Coder needs a local
-    # database. Hosts can still override it.
+    # and /var/lib/postgresql persistence cannot be disabled independently
+    # while Coder still expects a local database.
     services'.postgresql.enable = lib.mkDefault cfg.database.createLocally;
 
     # The upstream unit only orders after network.target, which races with
     # PostgreSQL init on first boot.
     systemd.services.coder.after = lib.mkIf cfg.database.createLocally ["postgresql.service"];
+    systemd.services.coder.requires = lib.mkIf cfg.database.createLocally ["postgresql.service"];
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [listenPort];
 
@@ -139,6 +144,7 @@ in {
         directory = "/var/lib/coder";
         user = "coder";
         group = "coder";
+        mode = "0700";
       }
     ];
   };

--- a/modules/nixos/apps/postgresql.nix
+++ b/modules/nixos/apps/postgresql.nix
@@ -7,6 +7,11 @@
 }: let
   cfg = config.services'.postgresql;
   user = myvars.username;
+  remoteAuthentication =
+    lib.concatMapStringsSep "\n" (
+      cidr: "host    sameuser        all             ${cidr}               scram-sha-256"
+    )
+    cfg.allowedCIDRs;
 in {
   options.services'.postgresql = {
     enable = lib.mkEnableOption "Enable PostgreSQL service";
@@ -29,10 +34,24 @@ in {
       description = "TCP port used by PostgreSQL";
     };
 
+    allowedCIDRs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = ["192.168.1.0/24"];
+      description = "Network CIDRs allowed to authenticate remotely when openFirewall is enabled";
+    };
+
     openFirewall = lib.mkEnableOption "Open firewall port for PostgreSQL";
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !cfg.openFirewall || cfg.allowedCIDRs != [];
+        message = "services'.postgresql.allowedCIDRs must not be empty when openFirewall is enabled";
+      }
+    ];
+
     services.postgresql = {
       enable = true;
       inherit (cfg) package dataDir;
@@ -44,9 +63,7 @@ in {
         max_connections = 100;
         log_connections = true;
         log_statement = "ddl";
-        logging_collector = true;
         log_disconnections = true;
-        log_destination = lib.mkForce "syslog";
         shared_buffers = "128MB";
         huge_pages = "try";
       };
@@ -66,24 +83,25 @@ in {
       ];
 
       # https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
-      authentication = lib.mkForce ''
+      authentication = ''
         # TYPE  DATABASE        USER            ADDRESS                 METHOD   OPTIONS
 
         # "local" is for Unix domain socket connections only
         local   all             all                                     peer     map=superuser_map
         # IPv4 local connections:
-        host    all             all             127.0.0.1/32            trust
+        host    all             all             127.0.0.1/32            scram-sha-256
         # IPv6 local connections:
-        host    all             all             ::1/128                 trust
+        host    all             all             ::1/128                 scram-sha-256
 
-        # Allow replication connections from localhost, by a user with the
-        # replication privilege.
-        local   replication     all                                     trust
-        host    replication     all             127.0.0.1/32            trust
-        host    replication     all             ::1/128                 trust
+        # Replication connections from localhost still require OS identity or
+        # a PostgreSQL password.
+        local   replication     all                                     peer     map=superuser_map
+        host    replication     all             127.0.0.1/32            scram-sha-256
+        host    replication     all             ::1/128                 scram-sha-256
 
-        # Other Remote Access - allow access only the database with the same name as the user
-        host    sameuser        all             0.0.0.0/0               scram-sha-256
+        # Remote access is opt-in per source network and only permits a
+        # database with the same name as the authenticated user.
+        ${remoteAuthentication}
       '';
     };
 


### PR DESCRIPTION
## 改动内容

- 改为要求 peer 或 SCRAM 认证，不再信任本地 TCP 访问
- 远程 PostgreSQL 访问改为按来源 CIDR 显式开启
- PostgreSQL 日志继续保留在系统日志（system journal）中
- 新增断言：启用本地 Coder 数据库时必须保留托管的 PostgreSQL 模块
- 调整启动顺序并让 Coder 强依赖 PostgreSQL，同时收紧 Coder 状态目录权限

## 验证

- `alejandra`
- `deadnix`
- Nix 语法检查
- 完整 flake 求值
