### PR TITLE
feat(nixos): 完成 Elaina 桌面环境集成

### DIFF
--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -1,13 +1,18 @@
+# Elaina — MECHREVO Wujie 14X laptop (Ryzen 7 8845HS, 32 GB DDR5, 1 TB SSD).
 {...}: {
   imports = [
     ./hardware.nix
   ];
 
   services' = {
+    accounts-daemon.enable = true;
     btrbk.enable = true;
     btrfs-scrub.enable = true;
+    gnome-keyring.enable = true;
     networkmanager.enable = true;
     openssh.enable = true;
+    pipewire.enable = true;
+    power-profiles-daemon.enable = true;
     printing.enable = true;
     smartd.enable = true;
     upower.enable = true;
@@ -33,7 +38,6 @@
     xdg-user-dirs.enable = true;
   };
 
-  security.rtkit.enable = true;
   security'.firewall.enable = true;
 
   tools'.dev.enable = true;

--- a/modules/nixos/desktop/applications.nix
+++ b/modules/nixos/desktop/applications.nix
@@ -67,11 +67,7 @@ in {
         mode = "0700";
       }
 
-      # Keyrings and certificate state used by desktop applications
-      {
-        directory = ".local/share/keyrings";
-        mode = "0700";
-      }
+      # Certificate state used by desktop applications
       {
         directory = ".local/share/pki";
         mode = "0700";

--- a/modules/nixos/desktop/niri.nix
+++ b/modules/nixos/desktop/niri.nix
@@ -10,6 +10,7 @@
 in {
   options.desktop'.niri = {
     enable = lib.mkEnableOption "Niri desktop environment";
+    autoLogin = lib.mkEnableOption "automatic login to the Niri session";
   };
 
   config = lib.mkIf cfg.enable {
@@ -20,14 +21,16 @@ in {
       package = pkgs.niri;
     };
 
-    # Autologin into Niri through the machine's greeter.
-    services.greetd.settings = {
-      initial_session = {
-        command = niriSession;
-        user = myvars.username;
+    services.greetd.settings =
+      {
+        default_session.command = "${lib.getExe pkgs.tuigreet} --remember --time --cmd ${niriSession}";
+      }
+      // lib.optionalAttrs cfg.autoLogin {
+        initial_session = {
+          command = niriSession;
+          user = myvars.username;
+        };
       };
-      default_session.command = "${lib.getExe pkgs.tuigreet} --remember --time --cmd ${niriSession}";
-    };
 
     preservation'.user.directories = [
       # Niri

--- a/modules/nixos/desktop/xdg-user-dirs.nix
+++ b/modules/nixos/desktop/xdg-user-dirs.nix
@@ -13,7 +13,7 @@ in {
 
       userDirs = {
         enable = true;
-        createDirectories = false;
+        createDirectories = true;
         desktop = "$HOME/Desktop";
         documents = "$HOME/Documents";
         download = "$HOME/Downloads";

--- a/modules/nixos/services/gnome-keyring.nix
+++ b/modules/nixos/services/gnome-keyring.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.services'.gnome-keyring;
+in {
+  options.services'.gnome-keyring.enable = lib.mkEnableOption "GNOME Keyring secret service";
+
+  config = {
+    services.gnome.gnome-keyring.enable = lib.mkIf cfg.enable true;
+
+    # Niri can also enable the native service, so follow its final state.
+    preservation'.user.directories = lib.optionals config.services.gnome.gnome-keyring.enable [
+      {
+        directory = ".local/share/keyrings";
+        mode = "0700";
+      }
+    ];
+  };
+}

--- a/modules/nixos/services/pipewire.nix
+++ b/modules/nixos/services/pipewire.nix
@@ -11,9 +11,14 @@ in {
 
   config = {
     services.pipewire = {
+      alsa.enable = lib.mkIf cfg.enable true;
       enable = lib.mkIf cfg.enable true;
+      pulse.enable = lib.mkIf cfg.enable true;
       wireplumber.enable = lib.mkIf cfg.enable true;
     };
+
+    # Let the audio server request real-time scheduling through RTKit.
+    security.rtkit.enable = lib.mkIf cfg.enable true;
 
     # Persistence follows the final service state, whoever turned it on.
     preservation'.user.directories =


### PR DESCRIPTION
## 改动内容

- 启用完整的 PipeWire 音频栈，并让 PipeWire 接管 RTKit
- 将 AccountsService、power profiles 和 GNOME Keyring 声明为显式的主机服务
- 把 keyring 的持久化条目移到其所属的服务模块
- Niri 自动登录改为可选开关，不再无条件启用
- 独立于 Preservation 创建已配置的 XDG 用户目录
- 在主机入口文件中注明 Elaina 的硬件角色

## 验证

- `alejandra`
- `deadnix`
- Nix 语法检查
- 完整 flake 求值
