### PR TITLE
feat(nixos): 在 Beelink 上启用存储维护

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -1,9 +1,12 @@
+# Beelink — headless home server (Ryzen 7 7735HS, 64 GB DDR5, 2 TB SSD).
 {...}: {
   imports = [
     ./hardware.nix
   ];
 
   services' = {
+    btrbk.enable = true;
+    btrfs-scrub.enable = true;
     coder = {
       enable = true;
       listenAddress = "0.0.0.0:34567";
@@ -11,9 +14,10 @@
       wildcardAccessUrl = "*.coder.in.ou.al";
       openFirewall = true;
     };
-    postgresql.enable = true;
     networkmanager.enable = true;
     openssh.enable = true;
+    postgresql.enable = true;
+    smartd.enable = true;
     vnstat.enable = true;
     zram.enable = true;
   };


### PR DESCRIPTION
## 改动内容

- 注明 Beelink 是无头（headless）家庭服务器
- 启用本地 Btrfs 快照与定期 scrub
- 启用 SMART 与 NVMe 健康监控
- 服务列表保持按模块名排序

本地快照能改善回滚覆盖，但仍与主机外的备份相互独立。

## 验证

- `alejandra`
- `deadnix`
- Nix 语法检查
- 完整 flake 求值
