### PR TITLE
perf(nixos): 为资源受限的 Router 虚拟机进行调优

### DIFF
--- a/hosts/nixos/router/default.nix
+++ b/hosts/nixos/router/default.nix
@@ -1,8 +1,17 @@
+# Router — planned PVE virtual-router guest (4 vCPU, 1 GB RAM, 32 GB disk).
+# It currently runs a minimal headless configuration on the existing LAN.
 {...}: {
   imports = [
-    ./network.nix
     ./hardware.nix
+    ./network.nix
   ];
+
+  # Avoid concurrent local builds exhausting the VM's 1 GB memory limit.
+  nix.settings.max-jobs = 1;
+
+  services.journald.extraConfig = ''
+    SystemMaxUse=128M
+  '';
 
   services' = {
     openssh.enable = true;


### PR DESCRIPTION
## 改动内容

- 记录规划中的 PVE 路由器虚拟机资源与当前角色
- 在 1 GB 虚拟机上把 Nix 并发构建任务数限制为 1
- 将持久化日志的用量上限设为 128 MB
- 统一主机 imports 的排列顺序

## 验证

- `alejandra`
- `deadnix`
- Nix 语法检查
- 完整 flake 求值
