### PR TITLE
refactor(nixos): 移除冗余的空硬件选项

### DIFF
--- a/hosts/nixos/beelink/hardware.nix
+++ b/hosts/nixos/beelink/hardware.nix
@@ -18,11 +18,9 @@
   boot = {
     initrd = {
       availableKernelModules = ["nvme" "xhci_pci" "thunderbolt" "usbhid" "usb_storage" "sd_mod"];
-      kernelModules = [];
     };
 
     kernelModules = ["kvm-amd"];
-    extraModulePackages = [];
     kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest-lto-x86_64-v3;
 
     loader = {

--- a/hosts/nixos/elaina/hardware.nix
+++ b/hosts/nixos/elaina/hardware.nix
@@ -18,11 +18,9 @@
   boot = {
     initrd = {
       availableKernelModules = ["nvme" "sd_mod" "thunderbolt" "usb_storage" "xhci_pci"];
-      kernelModules = [];
     };
 
     kernelModules = ["kvm-amd"];
-    extraModulePackages = [];
     kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest-lto-zen4;
 
     loader = {

--- a/hosts/nixos/router/hardware.nix
+++ b/hosts/nixos/router/hardware.nix
@@ -14,10 +14,6 @@
     kernelParams = ["audit=0" "net.ifnames=0"];
 
     initrd.availableKernelModules = ["uhci_hcd" "ehci_pci" "ahci" "virtio_pci" "virtio_scsi" "sd_mod" "sr_mod"];
-    initrd.kernelModules = [];
-    # The system runs as a PVE guest and does not host KVM guests itself.
-    kernelModules = [];
-    extraModulePackages = [];
 
     loader = {
       systemd-boot.enable = true;


### PR DESCRIPTION
## 改动内容

- 移除硬件探测生成的空的 initrd 内核模块列表
- 移除空的额外内核模块包列表
- 删除附着在空的 KVM 模块列表上、具有误导性的 Router 注释
- 保留所有实际生效的引导与硬件设置

## 验证

- `alejandra`
- `deadnix`
- Nix 语法检查
- 完整 flake 求值
