### PR TITLE
docs: 新增根分区落盘的 disko 示例并润色安装指南

### DIFF
--- a/docs/NixOS 安装指南.md
+++ b/docs/NixOS 安装指南.md
@@ -1,24 +1,33 @@
 # NixOS 安装指南
 
-本文档介绍如何从 NixOS 安装介质启动，使用独立的 Disko 配置创建文件系统，并通过本仓库的 Flake 安装 `elaina`。
+本文档介绍如何从 NixOS 安装介质启动，先用独立的 Disko 配置完成分区和格式化，再通过本仓库的 Flake 安装主机 `elaina`。
 
 > [!CAUTION]
-> Disko 会清空目标磁盘上的所有分区和数据。执行前请备份数据，并再次确认目标磁盘。
+> 下文的 Disko 命令会清空目标磁盘上的全部分区和数据。执行前请备份重要数据，并再次确认目标磁盘。
 
 ## Disko 配置
 
-仓库的 `docs/example/` 目录提供两份可以独立使用的 Disko 配置，同时也是当前磁盘布局的备份：
+仓库的 `docs/example/` 目录提供四份可独立使用的 Disko 配置，按根分区类型分为两组：
+
+**tmpfs 作根（当前布局，重启后根分区清空）**
 
 - [`luks-btrfs-subvolumes.nix`](./example/luks-btrfs-subvolumes.nix)：LUKS 加密，带 swap
 - [`btrfs-subvolumes.nix`](./example/btrfs-subvolumes.nix)：无加密，无 swap
 
-选择其中一份，下载为 `disko.nix`（以下以 LUKS 版本为例）：
+**根分区落盘（btrfs 子卷 `@root`，重启后保留）**
+
+- [`luks-btrfs-root.nix`](./example/luks-btrfs-root.nix)：LUKS 加密，带 swap
+- [`btrfs-root.nix`](./example/btrfs-root.nix)：无加密，无 swap
+
+仓库的主机配置固定按 tmpfs 根布局生成文件系统定义，推荐选择第一组；如果选择第二组，请同步调整主机配置中对应的文件系统定义。
+
+选定后下载为 `disko.nix`（下文以 LUKS tmpfs 版为例）：
 
 ```bash
 curl -o disko.nix https://raw.githubusercontent.com/27Aaron/Dotfiles/main/docs/example/luks-btrfs-subvolumes.nix
 ```
 
-安装前确认配置中的 `device` 与目标磁盘一致：
+编辑 `disko.nix`，把 `device` 改为目标磁盘，推荐使用 `/dev/disk/by-id/` 下的稳定路径：
 
 ```bash
 lsblk -o NAME,PATH,SIZE,MODEL,SERIAL
@@ -35,7 +44,7 @@ sudo nix --experimental-features "nix-command flakes" \
   --mode destroy,format,mount ./disko.nix
 ```
 
-Disko 会要求确认清空磁盘；使用 LUKS 版本时还会交互式询问密码。完成后确认文件系统已经挂载到 `/mnt`：
+Disko 会先要求确认清空磁盘，LUKS 版本还会交互式询问加密密码。完成后确认文件系统已挂载到 `/mnt`：
 
 ```bash
 findmnt -R /mnt
@@ -51,15 +60,20 @@ git clone https://github.com/27Aaron/Dotfiles.git ~/nix-config
 cd ~/nix-config
 ```
 
-生成不包含文件系统定义的硬件配置：
+生成不包含文件系统定义的硬件配置（文件系统定义由 Disko 和仓库配置负责）：
 
 ```bash
 sudo nixos-generate-config --no-filesystems --root /mnt
 ```
 
-检查 `/mnt/etc/nixos/hardware-configuration.nix`，将仍然需要的硬件探测结果合并到 `hosts/nixos/elaina/hardware.nix`，不要覆盖已有的 Disko、持久化和引导配置。
+查看 `/mnt/etc/nixos/hardware-configuration.nix`，把仍然需要的硬件探测结果合并进 `hosts/nixos/elaina/hardware.nix`，注意不要覆盖仓库中已有的 Disko、持久化和引导配置。
 
-确认 `vars/default.nix` 中的用户名、密码哈希、SSH 公钥和默认时区，以及 `hosts/nixos/<主机名>/default.nix` 中的系统状态版本正确，然后安装系统：
+安装前检查以下配置：
+
+- `vars/default.nix`：用户名、密码哈希、SSH 公钥、默认时区
+- `hosts/nixos/elaina/default.nix`：`system.stateVersion`
+
+然后安装系统：
 
 ```bash
 sudo nixos-install \
@@ -68,29 +82,29 @@ sudo nixos-install \
   --no-root-password
 ```
 
-安装完成后重启并拔出安装介质：
+安装完成后重启并移除安装介质：
 
 ```bash
 sudo reboot
 ```
 
-使用 LUKS 版本时，启动需要输入 LUKS 密码，然后使用 `vars/default.nix` 中配置的账户登录。
+使用 LUKS 版本时，开机需要先输入加密密码，再用 `vars/default.nix` 中配置的账户登录。
 
 > [!IMPORTANT]
-> 根文件系统使用 tmpfs，系统设计为将需要保留的数据存储到 `/persistent`；未持久化的数据会在重启后消失。
+> 根文件系统为 tmpfs，重启即清空；需要保留的数据由持久化机制统一存放在 `/persistent`，未持久化的内容重启后会丢失。
 
 ## 后续维护
 
-仓库中的 `justfile` 提供以下命令（`just` 和 `nh` 已由配置安装，flake 路径固定为 `~/nix-config`）：
+仓库的 `Justfile` 提供以下命令（`just` 和 `nh` 已随配置安装；`nh` 固定读取 `~/nix-config`，即上文的克隆路径）：
 
 ```bash
 just switch  # 构建并应用当前主机配置
 just check   # 检查格式、未使用声明和所有主机求值
 just update  # 更新 flake.lock
-just gc      # 清理旧的 generation 及无引用 Store 路径
+just gc      # 交互式清理旧 generation 及无引用 Store 路径
 ```
 
-CI 只检查格式、未使用声明和 Nix 语法。更新配置或依赖后，请在本地运行 `just check`，通过后再执行 `just switch`。
+CI 只检查格式、未使用声明和 Nix 语法。修改配置或依赖后，建议先在本地运行 `just check`，通过后再执行 `just switch`。
 
 ## 参考资料
 

--- a/docs/example/btrfs-root.nix
+++ b/docs/example/btrfs-root.nix
@@ -1,0 +1,88 @@
+{...}: {
+  disko.devices = {
+    disk.main = {
+      type = "disk";
+      device = "/dev/sda";
+
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            priority = 1;
+            size = "256M";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              extraArgs = [
+                "-n"
+                "BOOT"
+              ];
+              mountOptions = ["umask=0077"];
+            };
+          };
+
+          root = {
+            priority = 2;
+            size = "100%";
+            type = "8300";
+            content = {
+              type = "btrfs";
+              extraArgs = [
+                "-f"
+                "--csum"
+                "xxhash64"
+                "--label"
+                "NixOS"
+              ];
+              mountpoint = "/btr_pool";
+              mountOptions = [
+                "noatime"
+                "subvolid=5"
+              ];
+
+              subvolumes = {
+                "@nix" = {
+                  mountpoint = "/nix";
+                  mountOptions = [
+                    "compress=zstd:1"
+                    "discard=async"
+                    "noatime"
+                  ];
+                };
+
+                "@persistent" = {
+                  mountpoint = "/persistent";
+                  mountOptions = [
+                    "compress=zstd:1"
+                    "discard=async"
+                    "noatime"
+                  ];
+                };
+
+                "@root" = {
+                  mountpoint = "/";
+                  mountOptions = [
+                    "compress=zstd:1"
+                    "discard=async"
+                    "noatime"
+                  ];
+                };
+
+                "@snapshots" = {
+                  mountpoint = "/snapshots";
+                  mountOptions = [
+                    "compress=zstd:1"
+                    "discard=async"
+                    "noatime"
+                  ];
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/docs/example/luks-btrfs-root.nix
+++ b/docs/example/luks-btrfs-root.nix
@@ -1,0 +1,115 @@
+{...}: {
+  disko.devices = {
+    disk.main = {
+      type = "disk";
+      device = "/dev/sda";
+
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            priority = 1;
+            size = "1G";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              extraArgs = [
+                "-n"
+                "BOOT"
+              ];
+              mountOptions = ["umask=0077"];
+            };
+          };
+
+          luks = {
+            priority = 2;
+            size = "100%";
+            type = "8309";
+            content = {
+              type = "luks";
+              name = "crypted";
+              askPassword = true;
+              initrdUnlock = true;
+              settings = {
+                allowDiscards = true;
+                bypassWorkqueues = true;
+                crypttabExtraOpts = [
+                  "same-cpu-crypt"
+                  "submit-from-crypt-cpus"
+                  "token-timeout=10"
+                ];
+              };
+              extraFormatArgs = [
+                "--type"
+                "luks2"
+                "--pbkdf"
+                "argon2id"
+              ];
+
+              content = {
+                type = "btrfs";
+                extraArgs = [
+                  "-f"
+                  "--csum"
+                  "xxhash64"
+                  "--label"
+                  "NixOS"
+                ];
+                mountpoint = "/btr_pool";
+                mountOptions = [
+                  "noatime"
+                  "subvolid=5"
+                ];
+
+                subvolumes = {
+                  "@nix" = {
+                    mountpoint = "/nix";
+                    mountOptions = [
+                      "compress=zstd:1"
+                      "discard=async"
+                      "noatime"
+                    ];
+                  };
+
+                  "@persistent" = {
+                    mountpoint = "/persistent";
+                    mountOptions = [
+                      "compress=zstd:1"
+                      "discard=async"
+                      "noatime"
+                    ];
+                  };
+
+                  "@root" = {
+                    mountpoint = "/";
+                    mountOptions = [
+                      "compress=zstd:1"
+                      "discard=async"
+                      "noatime"
+                    ];
+                  };
+
+                  "@snapshots" = {
+                    mountpoint = "/snapshots";
+                    mountOptions = [
+                      "compress=zstd:1"
+                      "discard=async"
+                      "noatime"
+                    ];
+                  };
+
+                  "@swap" = {
+                    mountpoint = "/swap";
+                    swap.swapfile.size = "32769M";
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/docs/macOS 配置指南.md
+++ b/docs/macOS 配置指南.md
@@ -1,29 +1,29 @@
 # macOS 配置指南
 
-本文档介绍如何在全新 macOS 系统上安装 Homebrew 和 Lix，并使用本仓库的 Flake 初始化 nix-darwin。
+本文档介绍如何在全新的 macOS 上安装 Homebrew 和 Lix，并使用本仓库的 Flake 初始化 nix-darwin。
 
 > [!WARNING]
-> **[unstable] `x86_64-darwin` 平台即将停止支持**
+> **Intel Mac（`x86_64-darwin`）即将失去上游支持**
 >
-> 受开发精力和构建资源限制，Nixpkgs 26.05 将是最后一个支持 Intel Mac（`x86_64-darwin`）的版本。随着 [`release: stop building for x86_64-darwin`](https://github.com/NixOS/nixpkgs/pull/493096) 合入，Nixpkgs 26.11 和 unstable 将不再为该平台构建二进制包，也不再支持从源码构建。
+> 受上游开发精力和构建资源限制，Nixpkgs 26.05 将是最后一个支持 Intel Mac（`x86_64-darwin`）的版本。随着 [`release: stop building for x86_64-darwin`](https://github.com/NixOS/nixpkgs/pull/493096) 合入，Nixpkgs 26.11 和 unstable 将不再为该平台构建二进制包，也不再支持从源码构建。
 >
-> Intel Mac 用户应暂时固定在 Nixpkgs 26.05，并尽快迁移到 Apple Silicon 或其他受支持的平台。`allowDeprecatedx86_64Darwin` 只能隐藏弃用警告，不能恢复 unstable 的平台支持，也不建议长期自行维护整套软件包构建。
+> Intel Mac 用户应暂时固定在 Nixpkgs 26.05，并尽快迁移到 Apple Silicon 或其他受支持的平台。`allowDeprecatedx86_64Darwin` 只能隐藏弃用警告，无法恢复 unstable 的平台支持，长期自行维护整套软件包构建也不可取。
 >
 > Homebrew 预计不早于 2026 年 9 月将 Intel Mac 降为 Tier 3，并在 2027 年 9 月后完全停止支持。按照 Nixpkgs 26.05 发布说明采用的时间线，macOS 26 的安全更新预计也将在 2028 年结束。
 
-当前 Darwin 主机配置使用 `aarch64-darwin`，适用于 Apple Silicon Mac，不受上述变更影响。
+本仓库的 Darwin 主机为 `aarch64-darwin`（Apple Silicon），不受上述变更影响。
 
 ## 环境准备
 
 ### 安装 Homebrew
 
-nix-darwin 的 Homebrew 模块只负责管理软件，不会安装 Homebrew 本身：
+nix-darwin 的 Homebrew 模块只负责管理软件清单，不会安装 Homebrew 本身，需要先手动安装：
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-安装完成后，按照安装程序输出的提示配置 `brew shellenv`，然后确认命令可用：
+安装完成后，按安装程序输出的提示把 `brew shellenv` 写入 shell 配置，然后确认命令可用：
 
 ```bash
 brew --version
@@ -35,7 +35,7 @@ brew --version
 curl -sSf -L https://install.lix.systems/lix | sh -s -- install
 ```
 
-重新打开终端，然后确认 Lix 已生效：
+重新打开终端，确认 Lix 已生效：
 
 ```bash
 nix --version
@@ -50,7 +50,7 @@ git clone https://github.com/27Aaron/Dotfiles.git ~/Dotfiles
 cd ~/Dotfiles
 ```
 
-主机目录名必须与 `hostname -s` 的结果一致。仓库默认主机名为 `luna`；如果当前主机名不同，请重命名目录：
+主机目录名必须与 `hostname -s` 的结果一致。仓库默认主机为 `luna`，如果当前主机名不同，请重命名目录：
 
 ```bash
 host_name="$(hostname -s)"
@@ -64,15 +64,15 @@ mv hosts/darwin/luna "hosts/darwin/$host_name"
 - `modules/darwin/apps/homebrew.nix`：Homebrew 软件清单
 
 > [!CAUTION]
-> 当前配置使用 `homebrew.onActivation.cleanup = "zap"`。首次构建会卸载所有未在配置中声明的 Homebrew 软件，并删除 Cask 的关联文件。
+> 当前配置启用了 `homebrew.onActivation.cleanup = "zap"`：首次激活会卸载所有未在清单中声明的 Homebrew 软件，并删除 Cask 的关联文件。
 
-如果系统中已经安装了 Homebrew 软件，请先导出清单：
+如果系统中已经装过 Homebrew 软件，先导出清单：
 
 ```bash
 brew bundle dump --describe --force --file="$HOME/Desktop/Brewfile"
 ```
 
-根据导出的 Brewfile 更新 `modules/darwin/apps/homebrew.nix` 后再继续。
+对照导出的 Brewfile 补全 `modules/darwin/apps/homebrew.nix` 后再继续。
 
 ## 初始化 nix-darwin
 
@@ -83,11 +83,11 @@ sudo nix run nix-darwin/master#darwin-rebuild -- \
   switch --flake "path:.#$(hostname -s)"
 ```
 
-首次构建会应用 nix-darwin、Home Manager、Homebrew、系统偏好设置和 Touch ID sudo 配置。完成后重新打开终端。
+首次执行会依次应用 nix-darwin、Home Manager、Homebrew、系统偏好设置和 Touch ID sudo 配置。完成后重新打开终端，之后的日常维护直接使用 `just switch`。
 
 ## 后续维护
 
-仓库中的 `justfile` 提供以下命令：
+仓库的 `Justfile` 提供以下命令：
 
 ```bash
 just switch  # 构建并应用当前主机配置
@@ -96,9 +96,9 @@ just update  # 更新 flake.lock
 just gc      # 清理 7 天前的旧 generation 及无引用 Store 路径
 ```
 
-CI 只检查格式、未使用声明和 Nix 语法。更新配置或依赖后，请在本地运行 `just check`，通过后再执行 `just switch`。
+CI 只检查格式、未使用声明和 Nix 语法。修改配置或依赖后，建议先在本地运行 `just check`，通过后再执行 `just switch`。
 
-新增的 `.nix` 文件会由入口模块自动发现。常用配置目录如下：
+新增的 `.nix` 文件会被自动导入，无需手动登记。常用的配置目录：
 
 - `home/common/`：跨平台 Home Manager 配置
 - `home/darwin/`：macOS 专用 Home Manager 配置
@@ -107,11 +107,11 @@ CI 只检查格式、未使用声明和 Nix 语法。更新配置或依赖后，
 
 ### 编辑 Karabiner 配置
 
-启用 Homebrew 并安装清单中的 `karabiner-elements` 后，应用配置会直接在 `~/.config/karabiner/karabiner.json` 写入 Nix 生成的键位。这个 JSON 是排版后的普通文件，权限为 `0600`，可以在 Karabiner 设置界面或编辑器中修改，不会链接到 Nix store；Karabiner 会在文件变化时自动重载。
+Homebrew 启用且清单中包含 `karabiner-elements` 时，每次激活都会在 `~/.config/karabiner/karabiner.json` 写入由 Nix 生成的键位配置。这是一个排版过的普通 JSON 文件（权限 `0600`），不链接到 Nix store，可以在编辑器或 Karabiner 设置界面中直接修改；Karabiner 检测到文件变化后会自动重载。
 
-每次 `just switch` 都会先把现有 JSON 备份为同目录的 `karabiner.json.hm-bak`，覆盖上一份备份，再写入 Nix 配置。早期的时间戳备份也会清理，只保留这一份；备份是独立文件，不依赖 Nix store。
+每次 `just switch` 会先把现有 JSON 备份为同目录的 `karabiner.json.hm-bak`（覆盖上一份备份），再写入 Nix 配置；更早的时间戳备份会被清理，始终只保留一份。备份是独立文件，不依赖 Nix store。
 
-可以随时手动编辑 JSON，但下次 `just switch` 会覆盖这些修改，并把当时的内容留在备份中。需要长期保留的键位，请修改仓库中的 Nix 配置。若旧配置目录仍是软链接，先复制其内容并将链接换为普通目录，再应用配置。
+手动编辑随时可行，但下次 `just switch` 会用 Nix 配置覆盖这些修改，被覆盖前的内容会留在备份里。需要长期保留的键位，请修改仓库中的 Nix 配置。如果旧的 Karabiner 配置目录还是软链接，先把内容复制出来、换成普通目录，再执行 `just switch`。
 
 ## 参考资料
 


### PR DESCRIPTION
## 改动内容

### 新增两份根分区落盘的 Disko 配置

- `docs/example/btrfs-root.nix`：无加密、无 swap，根分区由 btrfs 子卷 `@root` 挂载到 `/`，重启后保留
- `docs/example/luks-btrfs-root.nix`：LUKS 加密 + swapfile，其余同上

与现有的两份 tmpfs 根示例（`btrfs-subvolumes.nix`、`luks-btrfs-subvolumes.nix`）除根分区外完全一致；tmpfs 版仍是推荐默认，因为主机配置固定按 tmpfs 根布局生成文件系统定义。

### 润色两份指南文案（步骤与事实不变）

**NixOS 安装指南**

- 四份示例配置按「tmpfs 作根 / 根分区落盘」分组列出
- 修正 `device` 的说法：模板是占位路径，实际需要修改而非确认
- 安装前检查项拆成清单，统一使用 `elaina` 主机路径
- `justfile` 更正为 `Justfile`；`just gc` 描述改为「交互式清理」（对应 `nh clean all --ask`）

**macOS 配置指南**

- Intel Mac 警告标题去掉模糊的 `[unstable]` 标记，正文事实不变
- 修正 `zap` 表述：`cleanup = "zap"` 发生在激活时而非构建时
- Karabiner 一节按文件性质、备份机制、注意事项重排
- `justfile` 同样更正为 `Justfile`

## 验证

- 两份新配置通过 `alejandra`、`deadnix` 和 `nix-instantiate --parse`
- 用仓库 flake 内的 disko 模块对两份新配置求值：分区结构、`fileSystems."/"`（`btrfs` + `subvol=@root`）、swap 条目均符合预期