### PR TITLE
ci: 自动化 PR 指派与标签

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,12 +3,14 @@ nixos:
       - any-glob-to-any-file:
           - "modules/nixos/**"
           - "hosts/nixos/**"
+          - "modules/common/**"
 
 darwin:
   - changed-files:
       - any-glob-to-any-file:
           - "modules/darwin/**"
           - "hosts/darwin/**"
+          - "modules/common/**"
 
 home-manager:
   - changed-files:
@@ -20,8 +22,3 @@ docs:
       - any-glob-to-any-file:
           - "docs/**"
           - "*.md"
-
-ci:
-  - changed-files:
-      - any-glob-to-any-file:
-          - ".github/**"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,27 @@
+nixos:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "modules/nixos/**"
+          - "hosts/nixos/**"
+
+darwin:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "modules/darwin/**"
+          - "hosts/darwin/**"
+
+home-manager:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "home/**"
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "*.md"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,21 @@
+name: assign
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Assign PR author
+        run: gh pr edit "$NUMBER" --repo "$REPO" --add-assignee "$AUTHOR"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/labeler@v5
-
       - name: Label by commit type
         run: |
           type=$(printf '%s' "$TITLE" | grep -oE '^(feat|fix|docs|refactor|perf|ci|chore)(\(|:|!)' || true)
@@ -28,3 +26,5 @@ jobs:
           NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           TITLE: ${{ github.event.pull_request.title }}
+
+      - uses: actions/labeler@v5

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,15 @@
+name: label
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/labeler@v5

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,3 +13,18 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/labeler@v5
+
+      - name: Label by commit type
+        run: |
+          type=$(printf '%s' "$TITLE" | grep -oE '^(feat|fix|docs|refactor|perf|ci|chore)(\(|:|!)' || true)
+          type=${type%?}
+          if [ -n "$type" ]; then
+            gh pr edit "$NUMBER" --repo "$REPO" --add-label "$type"
+          else
+            echo "Title has no conventional commit type prefix, skipping"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## 变更说明

新增两个轻量 workflow，为 PR 加自动化：

- `assign`：PR 打开或重开时自动把作者加入 Assignees
- `label`：两个维度打标，对齐历史 PR 的打标习惯
  - **范围**（`actions/labeler`，按改动路径）：`modules/nixos/**`、`hosts/nixos/**` → `nixos`；`modules/darwin/**`、`hosts/darwin/**` → `darwin`；`modules/common/**` → 同时打 `nixos` + `darwin`；`home/**` → `home-manager`；`docs/**`、根目录 `*.md` → `docs`
  - **类型**（解析标题前缀）：`feat` / `fix` / `docs` / `refactor` / `perf` / `ci` / `chore`，与约定式提交的 type 一致

全部复用仓库已有标签，无需新建。两个 workflow 均不运行 Nix，秒级完成，公共仓库 Actions 免费。本 PR 自身已实测：自动指派与标题打标均生效。

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
