### PR TITLE
feat(darwin): 补齐 Homebrew 包声明并新增 taps 选项

### DIFF
--- a/modules/darwin/apps/homebrew.nix
+++ b/modules/darwin/apps/homebrew.nix
@@ -21,6 +21,12 @@ in {
     };
 
     onActivation = {
+      upgrade = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Upgrade outdated Homebrew packages on activation";
+      };
+
       autoUpdate = lib.mkOption {
         type = lib.types.bool;
         default = false;
@@ -32,12 +38,15 @@ in {
         default = "zap";
         description = "How aggressively to remove packages not in the configuration";
       };
+    };
 
-      upgrade = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Upgrade outdated Homebrew packages on activation";
-      };
+    taps = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "anomalyco/tap"
+        "steipete/tap"
+      ];
+      description = "Homebrew taps to install";
     };
 
     masApps = lib.mkOption {
@@ -54,6 +63,13 @@ in {
       default = [
         # Disk & Cleanup
         "mole"
+
+        # AI Agents
+        "anomalyco/tap/opencode"
+        "pi-coding-agent"
+
+        # Code Statistics
+        "tokei"
       ];
       description = "Homebrew formulae to install";
     };
@@ -66,6 +82,7 @@ in {
         "cc-switch"
         "grok-build"
         "steipete/tap/codexbar"
+        "zcode"
 
         # Browser
         # "brave-browser"
@@ -91,8 +108,8 @@ in {
         "font-jetbrains-mono-nerd-font"
 
         # Hardware
-        # "monitorcontrol"
         "macs-fan-control"
+        "monitorcontrol"
 
         # Input & Keyboard
         "input-source-pro"
@@ -139,6 +156,7 @@ in {
       enable = true;
       inherit (cfg) enableFishIntegration enableZshIntegration masApps brews casks;
       onActivation = cfg.onActivation;
+      taps = cfg.taps;
     };
   };
 }


### PR DESCRIPTION
## 变更说明

- 新增 `apps'.homebrew.taps` 选项（默认 `anomalyco/tap`、`steipete/tap`），在 config 中接入原生 `homebrew.taps`，tap 声明从依赖 brew bundle 的自动 tap 改为显式声明
- `brews` 补齐 `anomalyco/tap/opencode`、`pi-coding-agent`（AI Agents）与 `tokei`（Code Statistics）
- `casks` 启用 `monitorcontrol`（原为注释）、新增 `zcode`（AI Development）
- `onActivation` 子选项顺序调整为与激活时实际执行顺序一致（upgrade → autoUpdate → cleanup）

本 PR 使 Luna 主机的声明列表与机器实际安装状态对齐，避免下次激活时 `cleanup = "zap"` 将未声明包误删。

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
