### PR TITLE
ci: 升级 labeler 至 v7 并添加 Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -27,4 +27,4 @@ jobs:
           REPO: ${{ github.repository }}
           TITLE: ${{ github.event.pull_request.title }}
 
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v7


### PR DESCRIPTION
## 变更说明

- `actions/labeler` 从 v5 升级到 v7：v5 面向 Node 20 打包，GitHub runner 已强制以 Node 24 执行并持续产生弃用警告；v6 的破坏性变更即 Node 24 运行时（GitHub 托管 runner 早已满足），v7 为 ESM 迁移。`.github/labeler.yml` 的 `changed-files` 配置格式无需变动
- 新增 `.github/dependabot.yml`：每周检查 GitHub Actions 依赖更新（本仓库 workflow 中唯一第三方 action 是 `actions/labeler`，合并后版本跟进将自动化）

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
