### PR TITLE
refactor(tools): 更名 coding-agents 并改用 HM 原生模块

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Justfile              switch / check / update / gc / fmt 等常用命令
 | `core'` | 主机与主用户元数据：hostName、timeZone、hashedPassword、sshAuthorizedKeys | `modules/*/system/core.nix` |
 | `system'` | 系统级杂项（darwin 系统偏好 `system'.defaults`） | `modules/darwin/system/` |
 | `apps'` | 应用级系统配置（darwin Homebrew `apps'.homebrew`） | `modules/darwin/apps/` |
-| `tools'` | 跨平台用户 CLI 工具分组（`tools'.dev`、`tools'.ai-cli`） | `modules/common/` |
+| `tools'` | 跨平台用户 CLI 工具分组（`tools'.dev`、`tools'.coding-agents`） | `modules/common/` |
 | `services'` | 主机级系统服务（含 PostgreSQL） | `modules/nixos/services/`、`modules/nixos/apps/` |
 | `desktop'` | 桌面功能与应用开关 | `modules/nixos/desktop/` |
 | `hardware'` | 可选硬件支持 | `modules/nixos/system/` |
@@ -84,7 +84,7 @@ Karabiner 配置位于 `home/darwin/apps/karabiner.nix`，不设独立开关：H
 
 桌面应用（Firefox、Kitty 等）的启用开关统一放在 `desktop'.apps.<app>.enable`，由 `modules/nixos/desktop/` 下的应用模块定义，模块内部通过 `hm'` 设置 Home Manager 的原生选项。不要为单个用户应用在 Home Manager 里新建自定义命名空间。
 
-跨平台的开发 CLI 工具集（gh、lazygit、uv、direnv、Nix 工具链）由 `tools'.dev.enable` 控制，安装、集成和持久化配置收敛在 `modules/common/tools.nix`；Shell 专属的 `uv` / `uvx` 补全分别放在 `home/common/fish.nix` 和 `home/common/zsh.nix`，并按命令是否存在加载。Claude Code 和 Codex 由 `tools'.ai-cli.enable` 控制，配置收敛在 `modules/common/ai-cli.nix`。其他带开关的内容不放入 `home/common/` 基线。`just` 属于所有主机共用的基线工具，放在 `home/common/misc.nix`。XDG 用户目录是桌面能力，由 `desktop'.xdg-user-dirs.enable` 控制，不放进 `home/nixos/` 基线。
+跨平台的开发 CLI 工具集（gh、lazygit、uv、direnv、Nix 工具链）由 `tools'.dev.enable` 控制，安装、集成和持久化配置收敛在 `modules/common/tools.nix`；Shell 专属的 `uv` / `uvx` 补全分别放在 `home/common/fish.nix` 和 `home/common/zsh.nix`，并按命令是否存在加载。Claude Code 和 Codex 由 `tools'.coding-agents.enable` 控制，配置收敛在 `modules/common/coding-agents.nix`。其他带开关的内容不放入 `home/common/` 基线。`just` 属于所有主机共用的基线工具，放在 `home/common/misc.nix`。XDG 用户目录是桌面能力，由 `desktop'.xdg-user-dirs.enable` 控制，不放进 `home/nixos/` 基线。
 
 ## 多设备配置
 

--- a/hosts/darwin/luna/default.nix
+++ b/hosts/darwin/luna/default.nix
@@ -3,12 +3,10 @@
   apps'.homebrew.enable = true;
   security'.touch-id.enable = true;
   system'.defaults.enable = true;
-  tools' = {
-    ai-cli.enable = true;
-    dev.enable = true;
-  };
+
+  tools'.coding-agents.enable = true;
+  tools'.dev.enable = true;
 
   nixpkgs.hostPlatform = "aarch64-darwin";
-
   system.stateVersion = 6;
 }

--- a/modules/common/coding-agents.nix
+++ b/modules/common/coding-agents.nix
@@ -1,18 +1,17 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }: let
-  cfg = config.tools'.ai-cli;
+  cfg = config.tools'.coding-agents;
 in {
-  options.tools'.ai-cli.enable = lib.mkEnableOption "AI coding CLIs (Claude Code and Codex)";
+  options.tools'.coding-agents.enable = lib.mkEnableOption "AI coding agents";
 
   config = lib.mkIf cfg.enable {
-    hm'.home.packages = with pkgs; [
-      claude-code
-      codex
-    ];
+    # Bare enable only installs the packages; leaving settings unmanaged keeps
+    # HM from taking over the live files inside ~/.claude and ~/.codex.
+    hm'.programs.claude-code.enable = true;
+    hm'.programs.codex.enable = true;
 
     hm'.home.shellAliases = {
       cc = "claude --dangerously-skip-permissions";


### PR DESCRIPTION
## 变更说明

- `modules/common/ai-cli.nix` 更名为 `coding-agents.nix`，命名空间 `tools'.ai-cli` → `tools'.coding-agents`，主机引用与 AGENTS.md 记录联动更新；`enable` 描述泛化为 "AI coding agents"，便于后续纳入更多编码代理
- Claude Code 与 Codex 改用 Home Manager 原生模块（`programs.claude-code` / `programs.codex`）安装，替代 `home.packages`；已验证裸 `enable` 仅装包、不生成配置文件（settings 均有 `mkIf` 守卫），`~/.claude`、`~/.codex` 内的活跃文件不受影响，后续需要时可通过 `settings` 选项声明式接管
- 整理 Luna 主机配置：`tools'` 嵌套展平为与其他命名空间一致的逐行写法，开关按字母序排列，`nixpkgs.hostPlatform` 与 `system.stateVersion` 归至末尾，与 AGENTS.md 的主机组织约定对齐

行为无任何变化，纯结构 refactor。

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
