### PR TITLE
docs: 统一各主机的描述注释

### DIFF
--- a/hosts/darwin/luna/default.nix
+++ b/hosts/darwin/luna/default.nix
@@ -1,4 +1,9 @@
-# Luna — primary MacBook Pro (M2 Max, 96 GB unified memory, 2 TB SSD).
+#####################################################
+#
+# Luna - MacBook Pro 2023 16-inch
+#   (M2 Max, 96 GB RAM, 4 TB SSD)
+#
+#####################################################
 {...}: {
   apps'.homebrew.enable = true;
   security'.touch-id.enable = true;

--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -1,4 +1,9 @@
-# Beelink — headless home server (Ryzen 7 7735HS, 64 GB DDR5, 2 TB SSD).
+#####################################################
+#
+# Beelink SER6 Pro VEST - homelab server
+#   (Ryzen 7 7735HS, 64 GB DDR5, 4 TB NVMe SSD)
+#
+#####################################################
 {...}: {
   imports = [
     ./hardware.nix

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -1,4 +1,9 @@
-# Elaina — MECHREVO Wujie 14X laptop (Ryzen 7 8845HS, 32 GB DDR5, 1 TB SSD).
+#####################################################
+#
+# Elaina - MECHREVO Wujie 14X laptop
+#   (Ryzen 7 8845HS, 32 GB DDR5, 2 TB SSD)
+#
+#####################################################
 {...}: {
   imports = [
     ./hardware.nix

--- a/hosts/nixos/router/default.nix
+++ b/hosts/nixos/router/default.nix
@@ -1,5 +1,9 @@
-# Router — planned PVE virtual-router guest (4 vCPU, 1 GB RAM, 32 GB disk).
-# It currently runs a minimal headless configuration on the existing LAN.
+#####################################################
+#
+# Router - A NixOS VM running on Proxmox
+#   (4 vCPU, 1 GB RAM, 32 GB disk)
+#
+#####################################################
 {...}: {
   imports = [
     ./hardware.nix


### PR DESCRIPTION
## 变更说明

- 四台主机（luna、beelink、elaina、router）的 `default.nix` 头部注释统一为横幅内两行式：第一行机器名与定位/型号，第二行括号内核心硬件规格
- beelink 补充型号 SER6 Pro VEST 与 homelab 定位
- 纯注释变更，不影响求值与构建

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
