### PR TITLE
refactor(persistence): 将 .icons 条目移回 cursors 并精简 themes

### DIFF
--- a/modules/nixos/desktop/cursors.nix
+++ b/modules/nixos/desktop/cursors.nix
@@ -18,5 +18,10 @@ in {
       size = 32;
       gtk.enable = true;
     };
+
+    # Cursor theme links managed by home.pointerCursor under ~/.icons.
+    preservation'.user.directories = [
+      ".icons"
+    ];
   };
 }

--- a/modules/nixos/desktop/themes.nix
+++ b/modules/nixos/desktop/themes.nix
@@ -10,56 +10,41 @@ in {
     enable = lib.mkEnableOption "GTK and icon themes";
   };
 
-  config = lib.mkMerge [
-    # Icon caches exist for either theme feature, so this stays outside the
-    # themes-only enable gate.
-    {
-      preservation'.user.directories =
-        lib.optionals (cfg.enable || config.desktop'.cursors.enable)
-        [".icons"];
-    }
+  config = lib.mkIf cfg.enable {
+    hm'.gtk = {
+      enable = true;
 
-    (lib.mkIf cfg.enable {
-      hm'.home.packages = with pkgs; [
-        gtk3
-        gtk4
-      ];
-
-      hm'.gtk = {
-        enable = true;
-
-        theme = {
-          package = pkgs.adw-gtk3;
-          name = "adw-gtk3-dark";
-        };
-
-        iconTheme = {
-          package = pkgs.papirus-icon-theme;
-          name = "Papirus-Dark";
-        };
-
-        font = {
-          package = pkgs.cantarell-fonts;
-          name = "Cantarell Regular";
-          size = 12;
-        };
+      theme = {
+        package = pkgs.adw-gtk3;
+        name = "adw-gtk3-dark";
       };
 
-      hm'.dconf.settings."org/gnome/desktop/interface" = {
-        color-scheme = "prefer-dark";
+      iconTheme = {
+        package = pkgs.papirus-icon-theme;
+        name = "Papirus-Dark";
       };
 
-      # State read and written through the managed GTK setup above.
-      preservation'.user.directories = [
-        {
-          directory = ".config/gtk-3.0";
-          mode = "0700";
-        }
-        {
-          directory = ".config/dconf";
-          mode = "0700";
-        }
-      ];
-    })
-  ];
+      font = {
+        package = pkgs.cantarell-fonts;
+        name = "Cantarell Regular";
+        size = 12;
+      };
+    };
+
+    hm'.dconf.settings."org/gnome/desktop/interface" = {
+      color-scheme = "prefer-dark";
+    };
+
+    # State read and written through the managed GTK setup above.
+    preservation'.user.directories = [
+      {
+        directory = ".config/gtk-3.0";
+        mode = "0700";
+      }
+      {
+        directory = ".config/dconf";
+        mode = "0700";
+      }
+    ];
+  };
 }


### PR DESCRIPTION
## 变更说明

- **`.icons` 持久化归位到 `cursors.nix`**：`~/.icons/<主题名>` 和 `~/.icons/default/index.theme` 由 Home Manager 的 `home.pointerCursor` 生成，按「持久化条目跟随所有权」约定移入 cursors 模块。
- **themes.nix 去掉跨模块判断**：删除 `cfg.enable || desktop'.cursors.enable` 的条件和对应的 `mkMerge` 结构，恢复为单一 `mkIf cfg.enable`；themes 只保留自己写入的状态（`.config/gtk-3.0`、`.config/dconf`）。
- **移除冗余的 `gtk3`/`gtk4` 用户包**：Home Manager 的 gtk 模块通过 `collectGtkPackages` 自动安装 theme/icon/font/cursor 包，裸装工具链库没有作用。

其余 desktop / services 模块已排查，持久化条目均跟随各自开关，无同类问题。

## 验证方式

- [x] `alejandra .` 格式通过
- [x] `deadnix --fail .` 通过
- [x] `nix flake check --no-build` 全部主机求值通过

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
