### PR TITLE
fix(persistence): 补齐缺失的持久化并按所有权归位条目

### DIFF
--- a/home/common/misc.nix
+++ b/home/common/misc.nix
@@ -28,4 +28,9 @@
     fastfetch
     nload
   ]);
+
+  # btop rewrites its config when settings change from the UI.
+  persist'.directories = [
+    ".config/btop"
+  ];
 }

--- a/modules/common/tools.nix
+++ b/modules/common/tools.nix
@@ -29,12 +29,17 @@ in {
       uv
     ];
 
-    # GitHub CLI account settings and fallback credentials.
+    # Runtime state of the toolset above: GitHub CLI account settings and
+    # fallback credentials, direnv .envrc allow-list, lazygit recent
+    # repositories, and uv-managed interpreters and tools.
     hm'.persist'.directories = [
       {
         directory = ".config/gh";
         mode = "0700";
       }
+      ".local/share/direnv"
+      ".local/state/lazygit"
+      ".local/share/uv"
     ];
   };
 }

--- a/modules/nixos/services/btrbk.nix
+++ b/modules/nixos/services/btrbk.nix
@@ -83,5 +83,15 @@ in {
       cfg.sourceVolume
       cfg.snapshotDirectory
     ];
+
+    # The service user's home and systemd StateDirectory.
+    preservation'.os.directories = [
+      {
+        directory = "/var/lib/btrbk";
+        user = "btrbk";
+        group = "btrbk";
+        mode = "0750";
+      }
+    ];
   };
 }

--- a/modules/nixos/services/openssh.nix
+++ b/modules/nixos/services/openssh.nix
@@ -34,5 +34,13 @@ in {
     };
 
     preservation'.os.directories = ["/etc/ssh"];
+
+    # Client keys and known_hosts; sshd also reads authorized_keys from here.
+    preservation'.user.directories = [
+      {
+        directory = ".ssh";
+        mode = "0700";
+      }
+    ];
   };
 }

--- a/modules/nixos/storage/persistence.nix
+++ b/modules/nixos/storage/persistence.nix
@@ -53,17 +53,7 @@ in {
         ".local/state/home-manager"
         ".local/state/nix/profiles"
 
-        # The configuration checkout used by nh.
-        {
-          directory = "nix-config";
-          mode = "0700";
-        }
-
         # Credentials without a managing module live here.
-        {
-          directory = ".ssh";
-          mode = "0700";
-        }
         {
           directory = ".gnupg";
           mode = "0700";

--- a/modules/nixos/system/nix.nix
+++ b/modules/nixos/system/nix.nix
@@ -20,4 +20,12 @@ in {
     enable = true;
     flake = lib.mkDefault "/home/${user}/nix-config";
   };
+
+  # The configuration checkout read by nh.
+  preservation'.user.directories = [
+    {
+      directory = "nix-config";
+      mode = "0700";
+    }
+  ];
 }


### PR DESCRIPTION
## 变更说明

全仓持久化审计（四个子代理分头扫描 services/system/desktop/home/hosts，关键事实对照锁定的 nixpkgs 与上游源码二次核实）后的修复：

**所有权归位**
- `~/.ssh` 从 `persistence.nix` 基线移入 `openssh.nix`：sshd 默认从家目录读 authorized_keys，且三台 NixOS 主机全部启用 openssh，移动无行为差异；`/etc/ssh`（主机密钥）本就在该模块，系统侧与用户侧凑齐。
- `nix-config` 移入 `nix.nix`：唯一消费者是 nh（flake 路径固定于此），模块无条件启用，所有主机行为不变。
- 基线只保留系统基础与共用条目（`.cache`、nix/HM 状态、`.gnupg`、os 级条目）。

**补缺（此前重启即丢）**
- `btrbk.nix` 补 `/var/lib/btrbk`：上游为 btrbk 实例声明的 `StateDirectory` 与服务用户家目录（远端备份时存放 known_hosts）。
- `tools.nix` 上报 direnv 的 `.envrc` 授权记录、lazygit 最近仓库、uv 安装的解释器与工具。
- `misc.nix` 上报 btop 的运行时回写配置 `.config/btop`（与 atuin/zoxide 同一 `persist'` 先例）。

**审计确认无问题（未改动）**：三台主机矩阵下无 disabled-but-declared 条目；gnome-keyring、pipewire、networkmanager、bluetooth、printing、postgresql、coder、greetd、firefox、vscode 等归属均正确。曾被子代理建议补 `.config/gtk-4.0`，经查 GTK4 源码书签写死 `gtk-3.0/bookmarks`，属误报，维持不持久化。

## 验证方式

- [x] `alejandra .` 格式通过
- [x] `deadnix --fail .` 通过
- [x] `nix flake check --no-build` 全部主机求值通过

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
