### PR TITLE
style: 统一单选项声明为花括号包裹形式

### DIFF
--- a/modules/common/coding-agents.nix
+++ b/modules/common/coding-agents.nix
@@ -5,7 +5,9 @@
 }: let
   cfg = config.tools'.coding-agents;
 in {
-  options.tools'.coding-agents.enable = lib.mkEnableOption "AI coding agents";
+  options.tools'.coding-agents = {
+    enable = lib.mkEnableOption "AI coding agents";
+  };
 
   config = lib.mkIf cfg.enable {
     # Bare enable only installs the packages; leaving settings unmanaged keeps

--- a/modules/common/tools.nix
+++ b/modules/common/tools.nix
@@ -6,7 +6,9 @@
 }: let
   cfg = config.tools'.dev;
 in {
-  options.tools'.dev.enable = lib.mkEnableOption "development CLI toolset for interactive hosts";
+  options.tools'.dev = {
+    enable = lib.mkEnableOption "development CLI toolset for interactive hosts";
+  };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = with pkgs; [

--- a/modules/darwin/security/touch-id.nix
+++ b/modules/darwin/security/touch-id.nix
@@ -3,7 +3,9 @@
   lib,
   ...
 }: {
-  options.security'.touch-id.enable = lib.mkEnableOption "Touch ID authentication for sudo";
+  options.security'.touch-id = {
+    enable = lib.mkEnableOption "Touch ID authentication for sudo";
+  };
 
   config = lib.mkIf config.security'.touch-id.enable {
     security.pam.services.sudo_local.touchIdAuth = true;

--- a/modules/darwin/system/defaults.nix
+++ b/modules/darwin/system/defaults.nix
@@ -13,7 +13,9 @@
   lib,
   ...
 }: {
-  options.system'.defaults.enable = lib.mkEnableOption "macOS system defaults";
+  options.system'.defaults = {
+    enable = lib.mkEnableOption "macOS system defaults";
+  };
 
   config = lib.mkIf config.system'.defaults.enable {
     system.defaults = {

--- a/modules/nixos/desktop/firefox.nix
+++ b/modules/nixos/desktop/firefox.nix
@@ -5,7 +5,9 @@
 }: let
   cfg = config.desktop'.apps.firefox;
 in {
-  options.desktop'.apps.firefox.enable = lib.mkEnableOption "Firefox";
+  options.desktop'.apps.firefox = {
+    enable = lib.mkEnableOption "Firefox";
+  };
 
   config = lib.mkIf cfg.enable {
     hm'.programs.firefox.enable = true;

--- a/modules/nixos/desktop/kitty.nix
+++ b/modules/nixos/desktop/kitty.nix
@@ -5,7 +5,9 @@
 }: let
   cfg = config.desktop'.apps.kitty;
 in {
-  options.desktop'.apps.kitty.enable = lib.mkEnableOption "Kitty terminal emulator";
+  options.desktop'.apps.kitty = {
+    enable = lib.mkEnableOption "Kitty terminal emulator";
+  };
 
   config = lib.mkIf cfg.enable {
     hm'.programs.kitty = {

--- a/modules/nixos/desktop/telegram.nix
+++ b/modules/nixos/desktop/telegram.nix
@@ -6,7 +6,9 @@
 }: let
   cfg = config.desktop'.apps.telegram;
 in {
-  options.desktop'.apps.telegram.enable = lib.mkEnableOption "AyuGram Desktop";
+  options.desktop'.apps.telegram = {
+    enable = lib.mkEnableOption "AyuGram Desktop";
+  };
 
   config = lib.mkIf cfg.enable {
     hm'.home.packages = [pkgs.ayugram-desktop];

--- a/modules/nixos/desktop/vscode.nix
+++ b/modules/nixos/desktop/vscode.nix
@@ -6,7 +6,9 @@
 }: let
   cfg = config.desktop'.apps.vscode;
 in {
-  options.desktop'.apps.vscode.enable = lib.mkEnableOption "Visual Studio Code";
+  options.desktop'.apps.vscode = {
+    enable = lib.mkEnableOption "Visual Studio Code";
+  };
 
   config = lib.mkIf cfg.enable {
     hm'.programs.vscode = {

--- a/modules/nixos/desktop/xdg-user-dirs.nix
+++ b/modules/nixos/desktop/xdg-user-dirs.nix
@@ -5,7 +5,9 @@
 }: let
   cfg = config.desktop'.xdg-user-dirs;
 in {
-  options.desktop'.xdg-user-dirs.enable = lib.mkEnableOption "XDG user directories";
+  options.desktop'.xdg-user-dirs = {
+    enable = lib.mkEnableOption "XDG user directories";
+  };
 
   config = lib.mkIf cfg.enable {
     hm'.xdg = {

--- a/modules/nixos/services/gnome-keyring.nix
+++ b/modules/nixos/services/gnome-keyring.nix
@@ -5,7 +5,9 @@
 }: let
   cfg = config.services'.gnome-keyring;
 in {
-  options.services'.gnome-keyring.enable = lib.mkEnableOption "GNOME Keyring secret service";
+  options.services'.gnome-keyring = {
+    enable = lib.mkEnableOption "GNOME Keyring secret service";
+  };
 
   config = {
     services.gnome.gnome-keyring.enable = lib.mkIf cfg.enable true;

--- a/modules/nixos/storage/persistence.nix
+++ b/modules/nixos/storage/persistence.nix
@@ -18,7 +18,9 @@ in {
       ["preservation" "preserveAt" "/persistent" "users" user])
   ];
 
-  options.storage'.persistence.enable = lib.mkEnableOption "Preservation for an ephemeral NixOS root";
+  options.storage'.persistence = {
+    enable = lib.mkEnableOption "Preservation for an ephemeral NixOS root";
+  };
 
   config = lib.mkIf cfg.enable {
     boot = {

--- a/modules/nixos/system/amdgpu.nix
+++ b/modules/nixos/system/amdgpu.nix
@@ -6,7 +6,9 @@
 }: let
   cfg = config.hardware'.amdgpu;
 in {
-  options.hardware'.amdgpu.enable = lib.mkEnableOption "AMD GPU support";
+  options.hardware'.amdgpu = {
+    enable = lib.mkEnableOption "AMD GPU support";
+  };
 
   config = lib.mkIf cfg.enable {
     hardware.graphics = {

--- a/modules/nixos/system/bluetooth.nix
+++ b/modules/nixos/system/bluetooth.nix
@@ -5,7 +5,9 @@
 }: let
   cfg = config.hardware'.bluetooth;
 in {
-  options.hardware'.bluetooth.enable = lib.mkEnableOption "Bluetooth support";
+  options.hardware'.bluetooth = {
+    enable = lib.mkEnableOption "Bluetooth support";
+  };
 
   config = {
     hardware.bluetooth.enable = lib.mkIf cfg.enable true;


### PR DESCRIPTION
## 变更说明

全仓扫描 `options.` 声明后，把 13 个模块中点号路径直赋值的 `enable` 声明，统一为与仓库其余模块（networkmanager、openssh、btrbk、disko 等）一致的花括号包裹形式：

```nix
# 改前
  options.services'.gnome-keyring.enable = lib.mkEnableOption "GNOME Keyring secret service";

# 改后
  options.services'.gnome-keyring = {
    enable = lib.mkEnableOption "GNOME Keyring secret service";
  };
```

涉及文件（每处 1 行改 3 行，共 +39/−13）：

- `modules/nixos/desktop/`：firefox、kitty、telegram、vscode、xdg-user-dirs（保持 `options.desktop'.apps.<名>` 粒度）
- `modules/nixos/`：services/gnome-keyring、storage/persistence、system/amdgpu、system/bluetooth
- `modules/common/`：tools（`tools'.dev`）、coding-agents（`tools'.coding-agents`）
- `modules/darwin/`：security/touch-id、system/defaults

纯样式调整：选项名、描述文字均未改动，求值语义不变。

## 验证方式

- [x] `alejandra .` 格式通过
- [x] `deadnix --fail .` 通过
- [x] `nix flake check --no-build` 全部主机求值通过（含 darwin）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
