### PR TITLE
refactor: 按旁路启用核实收敛服务模块的持久化判定

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,9 @@ Justfile              switch / check / update / gc / fmt 等常用命令
 可选模块通常定义自己的 `enable` 选项，并用该选项包住全部配置：
 
 ```nix
-options.services'.example.enable = lib.mkEnableOption "Example service";
+options.services'.example = {
+  enable = lib.mkEnableOption "Example service";
+};
 
 config = lib.mkIf cfg.enable {
   # module-owned configuration
@@ -108,7 +110,7 @@ NixOS 上 `nh` 的 flake 路径固定为 `/home/<username>/nix-config`（`module
 
 - `persistence.nix` 只放机器启动所需、系统基础和所有设备共用的用户基线（缓存、无归属模块的凭据等），并把 Home Manager 通过 `persist'` 上报的条目汇入 preservation 选项
 - 纯 Home Manager 工具无法直接写 NixOS 选项，通过 `home/common/persist.nix` 定义的 `persist'` 选项上报自己的状态目录和文件（例如 Atuin、Zoxide）
-- 桌面共用状态（GTK、dconf、密钥环等）跟随生成或消费它们的桌面功能声明，例如 GTK/dconf 放在 `desktop/themes.nix`；由上游模块间接触发的系统服务（如 PipeWire、AccountsService）也拥有自己的服务模块和 `services'.<name>.enable` 开关，持久化按最终服务状态判定
+- 桌面共用状态（GTK、dconf、密钥环等）跟随生成或消费它们的桌面功能声明，例如 GTK/dconf 放在 `desktop/themes.nix`；由上游模块间接触发的系统服务（如 GNOME Keyring 会被 niri 开启、power-profiles-daemon 会被 DMS 开启）也拥有自己的服务模块和 `services'.<name>.enable` 开关，持久化按最终服务状态判定
 - 服务自己的状态由服务模块声明，例如 VNStat 放在 `services/vnstat.nix`；桌面功能和应用由 `desktop/` 下定义各自开关的模块声明，例如 Firefox 放在 `desktop/firefox.nix`
 - 功能模块不要重复判断 `storage'.persistence.enable`；Preservation 自身会根据总开关决定是否生成实际挂载
 - 没有启用的服务、桌面功能或应用，不得加入它们专属的持久化目录

--- a/modules/darwin/security/touch-id.nix
+++ b/modules/darwin/security/touch-id.nix
@@ -2,12 +2,14 @@
   config,
   lib,
   ...
-}: {
+}: let
+  cfg = config.security'.touch-id;
+in {
   options.security'.touch-id = {
     enable = lib.mkEnableOption "Touch ID authentication for sudo";
   };
 
-  config = lib.mkIf config.security'.touch-id.enable {
+  config = lib.mkIf cfg.enable {
     security.pam.services.sudo_local.touchIdAuth = true;
   };
 }

--- a/modules/darwin/system/defaults.nix
+++ b/modules/darwin/system/defaults.nix
@@ -12,12 +12,14 @@
   config,
   lib,
   ...
-}: {
+}: let
+  cfg = config.system'.defaults;
+in {
   options.system'.defaults = {
     enable = lib.mkEnableOption "macOS system defaults";
   };
 
-  config = lib.mkIf config.system'.defaults.enable {
+  config = lib.mkIf cfg.enable {
     system.defaults = {
       menuExtraClock.Show24Hour = true; # show 24 hour clock
       menuExtraClock.ShowSeconds = true;

--- a/modules/nixos/services/accounts-daemon.nix
+++ b/modules/nixos/services/accounts-daemon.nix
@@ -9,11 +9,10 @@ in {
     enable = lib.mkEnableOption "AccountsService daemon";
   };
 
-  config = {
-    services.accounts-daemon.enable = lib.mkIf cfg.enable true;
+  config = lib.mkIf cfg.enable {
+    services.accounts-daemon.enable = true;
 
-    # Persistence follows the final service state, whoever turned it on.
-    preservation'.os.directories = lib.optionals config.services.accounts-daemon.enable [
+    preservation'.os.directories = [
       {
         directory = "/var/lib/AccountsService";
         mode = "0775";

--- a/modules/nixos/services/pipewire.nix
+++ b/modules/nixos/services/pipewire.nix
@@ -9,32 +9,28 @@ in {
     enable = lib.mkEnableOption "PipeWire audio stack";
   };
 
-  config = {
+  config = lib.mkIf cfg.enable {
     services.pipewire = {
-      alsa.enable = lib.mkIf cfg.enable true;
-      enable = lib.mkIf cfg.enable true;
-      pulse.enable = lib.mkIf cfg.enable true;
-      wireplumber.enable = lib.mkIf cfg.enable true;
+      enable = true;
+      alsa.enable = true;
+      pulse.enable = true;
+      wireplumber.enable = true;
     };
 
     # Let the audio server request real-time scheduling through RTKit.
-    security.rtkit.enable = lib.mkIf cfg.enable true;
+    security.rtkit.enable = true;
 
-    # Persistence follows the final service state, whoever turned it on.
-    preservation'.user.directories =
-      lib.optionals (config.services.pulseaudio.enable || config.services.pipewire.pulse.enable) [
-        # PulseAudio compatibility cookie
-        {
-          directory = ".config/pulse";
-          mode = "0700";
-        }
-      ]
-      ++ lib.optionals config.services.pipewire.wireplumber.enable [
-        # WirePlumber
-        {
-          directory = ".local/state/wireplumber";
-          mode = "0700";
-        }
-      ];
+    preservation'.user.directories = [
+      # PulseAudio compatibility cookie
+      {
+        directory = ".config/pulse";
+        mode = "0700";
+      }
+      # WirePlumber saved routes and devices
+      {
+        directory = ".local/state/wireplumber";
+        mode = "0700";
+      }
+    ];
   };
 }

--- a/modules/nixos/services/power-profiles-daemon.nix
+++ b/modules/nixos/services/power-profiles-daemon.nix
@@ -12,7 +12,8 @@ in {
   config = {
     services.power-profiles-daemon.enable = lib.mkIf cfg.enable true;
 
-    # Persistence follows the final service state, whoever turned it on.
+    # DMS enables this daemon on its own, so persistence follows the final
+    # service state, whoever turned it on.
     preservation'.os.directories = lib.optionals config.services.power-profiles-daemon.enable [
       # Power management
       "/var/lib/power-profiles-daemon"

--- a/modules/nixos/services/upower.nix
+++ b/modules/nixos/services/upower.nix
@@ -9,11 +9,10 @@ in {
     enable = lib.mkEnableOption "UPower power management daemon";
   };
 
-  config = {
-    services.upower.enable = lib.mkIf cfg.enable true;
+  config = lib.mkIf cfg.enable {
+    services.upower.enable = true;
 
-    # Persistence follows the final service state, whoever turned it on.
-    preservation'.os.directories = lib.optionals config.services.upower.enable [
+    preservation'.os.directories = [
       "/var/lib/upower"
     ];
   };

--- a/modules/nixos/system/bluetooth.nix
+++ b/modules/nixos/system/bluetooth.nix
@@ -9,11 +9,10 @@ in {
     enable = lib.mkEnableOption "Bluetooth support";
   };
 
-  config = {
-    hardware.bluetooth.enable = lib.mkIf cfg.enable true;
+  config = lib.mkIf cfg.enable {
+    hardware.bluetooth.enable = true;
 
-    # Persistence follows the final service state, whoever turned it on.
-    preservation'.os.directories = lib.optionals config.hardware.bluetooth.enable [
+    preservation'.os.directories = [
       # Bluetooth
       {
         directory = "/var/lib/bluetooth";


### PR DESCRIPTION
## 变更说明

延续 #48 的持久化审计与 pipewire 简化的讨论，对全部使用 final-state（`lib.optionals config.services.*.enable`）判定的模块，逐个对照锁定的 nixpkgs 源码核实是否存在**仓库内可达**的旁路启用，分两类处理：

**收敛为 `mkIf cfg.enable`（旁路不存在，行为不变）**

- `pipewire.nix`：`pulse`/`wireplumber`/`alsa` 只有本模块自己开启；
- `accounts-daemon.nix`：上游旁路是 GDM/lightdm/regreet，本仓用 greetd + tuigreet，不可达；
- `upower.nix`：旁路是 noctalia/cosmic/tuned 等，本仓未使用；
- `bluetooth.nix`：`hardware.bluetooth` 无任何上游模块自动开启。

**保留 final-state 判定（旁路真实存在，验证过）**

- `gnome-keyring.nix`：niri 上游模块 `programs/wayland/niri.nix:46` 会 `gnome.gnome-keyring.enable = lib.mkDefault true`；
- `power-profiles-daemon.nix`：dms-shell 上游模块会直接开启，elaina 正在使用；注释补充了依据。

**顺带统一**

- darwin 的 `touch-id.nix`、`defaults.nix` 改用 `cfg` 别名（原为 `config.X.enable` 全路径）；
- `AGENTS.md`：option 示例改为花括号包裹形式；final-state 的例子换成上述两个已验证的（原 AccountsService 的旁路 GDM 在本仓同样不可达）。

现有主机上所有条件与模块开关等价，行为不变。

## 验证方式

- [x] `alejandra .` 格式通过
- [x] `deadnix --fail .` 通过
- [x] `nix flake check --no-build` 全部主机求值通过（含 darwin）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
