### PR TITLE
fix: 修正各主机与 Home Manager 的 stateVersion 为 26.05

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -34,7 +34,7 @@ in {
   home = {
     username = myvars.username;
     inherit (platform) homeDirectory;
-    stateVersion = "26.11";
+    stateVersion = "26.05";
   };
 
   programs = {

--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -31,5 +31,5 @@
 
   tools'.dev.enable = true;
 
-  system.stateVersion = "26.11";
+  system.stateVersion = "26.05";
 }

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -47,5 +47,5 @@
 
   tools'.dev.enable = true;
 
-  system.stateVersion = "26.11";
+  system.stateVersion = "26.05";
 }

--- a/hosts/nixos/router/default.nix
+++ b/hosts/nixos/router/default.nix
@@ -25,5 +25,5 @@
 
   security'.firewall.enable = true;
 
-  system.stateVersion = "26.11";
+  system.stateVersion = "26.05";
 }


### PR DESCRIPTION
26.11 尚未发布（预计 2026-11），当前已发布的最新版本为 26.05。stateVersion 是"首次安装版本"的迁移基线标记，与软件版本无关（包版本仍由 nixpkgs-unstable 输入决定），因此统一修正为 26.05：

- 三台 NixOS 主机（elaina / beelink / router）的 `system.stateVersion`
- Home Manager 的 `home.stateVersion`
