### PR TITLE
fix(karabiner): 修复激活脚本失败路径引用未定义变量

### DIFF
--- a/home/darwin/apps/karabiner.nix
+++ b/home/darwin/apps/karabiner.nix
@@ -105,7 +105,7 @@ in {
         mkdir -p -- "$dir"
         target="$dir/karabiner.json"
         work=$(mktemp -d -- "$dir/.activation.XXXXXX")
-        trap 'rm -rf -- "$work"' EXIT
+        trap 'if [[ -v work ]]; then rm -rf -- "$work"; fi' EXIT
         trap 'exit 1' HUP INT TERM
 
         jq -e . "$gen" > "$work/karabiner.json"


### PR DESCRIPTION
激活脚本运行于 `set -eu` 下，`mktemp -d` 失败直接退出时，EXIT trap 里的 `rm -rf -- "$work"` 会因 `work` 未定义再抛一次 unbound variable 错误，遮蔽真实失败原因。改为 trap 中先判断 `[[ -v work ]]` 再清理。
