### PR TITLE
fix(services): btrfs-scrub 定时错峰避开 btrbk

### DIFF
--- a/modules/nixos/services/btrfs-scrub.nix
+++ b/modules/nixos/services/btrfs-scrub.nix
@@ -10,7 +10,9 @@ in {
 
     interval = lib.mkOption {
       type = lib.types.str;
-      default = "monthly";
+      # First day of the month at 04:00, away from the 00:00/12:00 snapshot
+      # slots of btrbk so the long scrub does not overlap with backups.
+      default = "*-*-01 04:00:00";
       description = "Systemd calendar expression controlling scrub frequency";
     };
   };


### PR DESCRIPTION
scrub 原默认 `monthly`（每月 1 日 00:00）与 btrbk 默认快照槽 `*-*-* 00,12:00:00` 在月初 00:00 必然重叠，且两个 timer 均 `Persistent=true`，开机追赶时也会同时执行。scrub 是长时重 IO 任务，改为每月 1 日 04:00，避开 btrbk 的快照窗口；elaina / beelink 均使用默认值，无需主机侧改动。
