### PR TITLE
refactor(desktop): greetd 持有登录命令，niri 仅注册会话

### DIFF
--- a/modules/nixos/desktop/greetd.nix
+++ b/modules/nixos/desktop/greetd.nix
@@ -1,18 +1,31 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }: let
   cfg = config.desktop'.greetd;
 in {
   options.desktop'.greetd = {
     enable = lib.mkEnableOption "Greetd login manager with Tuigreet";
+
+    sessionCommand = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "niri-session";
+      description = ''
+        Session command Tuigreet launches after login. Null keeps the
+        greeter default. Set by the desktop module that owns the session,
+        so the greeter binary choice stays inside this module.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     services.greetd = {
       enable = true;
       useTextGreeter = true;
+      settings.default_session.command = lib.mkIf (cfg.sessionCommand != null) "${lib.getExe pkgs.tuigreet} --remember --time --cmd ${cfg.sessionCommand}";
     };
 
     preservation'.os.directories = [

--- a/modules/nixos/desktop/niri.nix
+++ b/modules/nixos/desktop/niri.nix
@@ -16,21 +16,18 @@ in {
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [pkgs.xwayland-satellite];
 
-    programs.niri = {
-      enable = true;
-      package = pkgs.niri;
-    };
+    programs.niri.enable = true;
 
-    services.greetd.settings =
-      {
-        default_session.command = "${lib.getExe pkgs.tuigreet} --remember --time --cmd ${niriSession}";
-      }
-      // lib.optionalAttrs cfg.autoLogin {
-        initial_session = {
-          command = niriSession;
-          user = myvars.username;
-        };
+    # Register the session with greetd when it drives the login screen; the
+    # greeter command itself is assembled by the greetd module.
+    desktop'.greetd.sessionCommand = lib.mkIf config.desktop'.greetd.enable niriSession;
+
+    services.greetd.settings = lib.mkIf (cfg.autoLogin && config.desktop'.greetd.enable) {
+      initial_session = {
+        command = niriSession;
+        user = myvars.username;
       };
+    };
 
     preservation'.user.directories = [
       # Niri


### PR DESCRIPTION
原先 niri 直接覆写 `services.greetd.settings.default_session.command` 并硬编码 tuigreet 路径：只开 niri 不开 greetd 时该配置静默悬空；将来 greetd 换图形 greeter 时此处的 tuigreet 引用也会失效。

改为 greetd 模块新增 `sessionCommand` 选项并持有 `tuigreet --remember --time --cmd …` 的命令拼装，niri 通过该选项注册 `niri-session`，autoLogin 的 `initial_session` 也加了 greetd 启用守卫。greeter 二进制的选择从此只存在于 greetd 模块。已求值验证最终登录命令与改动前一致。顺带删除 niri 模块中与默认值相同的 `programs.niri.package`。
