### PR TITLE
refactor(storage): 合并 disko 的 LUKS 与非 LUKS 分支

### DIFF
--- a/modules/nixos/storage/disko.nix
+++ b/modules/nixos/storage/disko.nix
@@ -41,6 +41,23 @@
         swap.swapfile.size = cfg.swapSize;
       };
     };
+
+  btrfsContent = {
+    type = "btrfs";
+    extraArgs = [
+      "-f"
+      "--csum"
+      "xxhash64"
+      "--label"
+      "NixOS"
+    ];
+    mountpoint = "/btr_pool";
+    mountOptions = [
+      "noatime"
+      "subvolid=5"
+    ];
+    subvolumes = btrfsSubvolumes;
+  };
 in {
   imports = [inputs.disko.nixosModules.disko];
 
@@ -140,22 +157,7 @@ in {
                       "--pbkdf"
                       "argon2id"
                     ];
-                    content = {
-                      type = "btrfs";
-                      extraArgs = [
-                        "-f"
-                        "--csum"
-                        "xxhash64"
-                        "--label"
-                        "NixOS"
-                      ];
-                      mountpoint = "/btr_pool";
-                      mountOptions = [
-                        "noatime"
-                        "subvolid=5"
-                      ];
-                      subvolumes = btrfsSubvolumes;
-                    };
+                    content = btrfsContent;
                   };
                 };
               }
@@ -163,22 +165,7 @@ in {
                 root = {
                   priority = 2;
                   size = "100%";
-                  content = {
-                    type = "btrfs";
-                    extraArgs = [
-                      "-f"
-                      "--csum"
-                      "xxhash64"
-                      "--label"
-                      "NixOS"
-                    ];
-                    mountpoint = "/btr_pool";
-                    mountOptions = [
-                      "noatime"
-                      "subvolid=5"
-                    ];
-                    subvolumes = btrfsSubvolumes;
-                  };
+                  content = btrfsContent;
                 };
               }
             );


### PR DESCRIPTION
LUKS 与非 LUKS 两个分支的 btrfs content（`extraArgs`、`mountpoint=/btr_pool`、`subvolid=5`、`subvolumes`）原先整块重复，调整压缩算法或 label 需要同步两处。提取 `btrfsContent` 到 `let`，两个分支仅剩 LUKS 包裹层的差异，与已有的 `btrfsSubvolumes` 提取风格一致。生成结果不变。
