### PR TITLE
refactor(router): systemd-networkd 改用类型化选项

### DIFF
--- a/hosts/nixos/router/network.nix
+++ b/hosts/nixos/router/network.nix
@@ -9,13 +9,11 @@
 
   systemd.network.networks."10-eth0" = {
     matchConfig.Name = "eth0";
-    networkConfig = {
-      # IPv4 comes from the static address; IPv6 addresses and routes are
-      # obtained through DHCPv6 and router advertisements.
-      Address = "10.77.77.66/24";
-      Gateway = "10.77.77.1";
-      DNS = ["10.77.77.1"];
-      DHCP = "ipv6";
-    };
+    # IPv4 comes from the static address; IPv6 addresses and routes are
+    # obtained through DHCPv6 and router advertisements.
+    address = ["10.77.77.66/24"];
+    gateway = ["10.77.77.1"];
+    dns = ["10.77.77.1"];
+    networkConfig.DHCP = "ipv6";
   };
 }


### PR DESCRIPTION
静态地址、网关、DNS 原先以 `Address` / `Gateway` / `DNS` 原始键写入 `networkConfig`（`[Network]` 段的遗留简写），绕过了模块系统的类型检查与列表合并。改用 NixOS 顶层类型化选项 `address` / `gateway` / `dns`，拼写错误在求值期即报错，多模块追加时正确合并。`matchConfig.Name` 与 `networkConfig.DHCP` 无对应类型化选项，保持原样。已求值验证渲染结果与原先一致。
