### PR TITLE
perf(home): 跳过选项手册构建

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -37,7 +37,7 @@ in {
     stateVersion = "26.05";
   };
 
-  programs = {
-    man.enable = false;
-  };
+  # The second switch is what skips building the option manual; man.enable alone does not.
+  programs.man.enable = false;
+  manual.manpages.enable = false;
 }


### PR DESCRIPTION
`programs.man.enable = false` 与 Home Manager 的选项手册构建没有联动，`manual.manpages.enable` 默认 `true`，每次激活仍会做一次全量选项文档求值与构建。显式关闭它，缩短所有主机的激活时间；顺带将单选项声明合并为一行。
