### PR TITLE
refactor(home): 移除未使用的 nix-index

### DIFF
--- a/home/common/nix-index.nix
+++ b/home/common/nix-index.nix
@@ -1,7 +1,0 @@
-{
-  programs.nix-index = {
-    enable = true;
-    enableFishIntegration = true;
-    enableZshIntegration = true;
-  };
-}


### PR DESCRIPTION
移除 nix-index 及其 fish / zsh 的 command-not-found 集成。本地生成索引数据库需要一次全量 nixpkgs 求值，实际使用频率不足以覆盖该成本；如将来需要，可接入 nix-index-database 的预构建数据库方案。
