### PR TITLE
chore: 清理冗余声明与选项描述

### DIFF
--- a/modules/common/nix.nix
+++ b/modules/common/nix.nix
@@ -15,7 +15,6 @@
         "nix-command"
         "flakes"
       ];
-      builders-use-substitutes = true;
     };
   };
 

--- a/modules/common/tools.nix
+++ b/modules/common/tools.nix
@@ -19,10 +19,7 @@ in {
 
     hm'.programs.direnv = {
       enable = true;
-      nix-direnv = {
-        enable = true;
-        package = pkgs.nix-direnv;
-      };
+      nix-direnv.enable = true;
     };
 
     hm'.home.packages = with pkgs; [

--- a/modules/nixos/apps/coder.nix
+++ b/modules/nixos/apps/coder.nix
@@ -15,7 +15,7 @@
     || lib.hasPrefix "[::1]" cfg.listenAddress;
 in {
   options.services'.coder = {
-    enable = lib.mkEnableOption "Enable Coder server";
+    enable = lib.mkEnableOption "Coder server";
 
     listenAddress = lib.mkOption {
       type = lib.types.str;
@@ -132,8 +132,10 @@ in {
 
     # The upstream unit only orders after network.target, which races with
     # PostgreSQL init on first boot.
-    systemd.services.coder.after = lib.mkIf cfg.database.createLocally ["postgresql.service"];
-    systemd.services.coder.requires = lib.mkIf cfg.database.createLocally ["postgresql.service"];
+    systemd.services.coder = lib.mkIf cfg.database.createLocally {
+      after = ["postgresql.service"];
+      requires = ["postgresql.service"];
+    };
 
     networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [listenPort];
 

--- a/modules/nixos/apps/postgresql.nix
+++ b/modules/nixos/apps/postgresql.nix
@@ -14,7 +14,7 @@
     cfg.allowedCIDRs;
 in {
   options.services'.postgresql = {
-    enable = lib.mkEnableOption "Enable PostgreSQL service";
+    enable = lib.mkEnableOption "PostgreSQL service";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/modules/nixos/desktop/applications.nix
+++ b/modules/nixos/desktop/applications.nix
@@ -6,6 +6,9 @@
 }: let
   cfg = config.desktop'.applications;
 in {
+  # Baseline set of file and media applications installed together on every
+  # desktop host; apps that carry their own configuration live in separate
+  # desktop'.apps.<app> modules instead.
   options.desktop'.applications = {
     enable = lib.mkEnableOption "desktop file and media applications";
   };

--- a/modules/nixos/desktop/xdg-user-dirs.nix
+++ b/modules/nixos/desktop/xdg-user-dirs.nix
@@ -21,8 +21,8 @@ in {
         download = "$HOME/Downloads";
         music = "$HOME/Music";
         pictures = "$HOME/Pictures";
-        publicShare = "/var/empty";
-        templates = "/var/empty";
+        publicShare = null;
+        templates = null;
         videos = "$HOME/Videos";
       };
       configFile."user-dirs.locale".text = "en_US";

--- a/modules/nixos/system/nix.nix
+++ b/modules/nixos/system/nix.nix
@@ -1,13 +1,11 @@
 {
   lib,
   myvars,
-  pkgs,
   ...
 }: let
   user = myvars.username;
 in {
   nix = {
-    package = pkgs.nix;
     gc.dates = lib.mkDefault "weekly";
     settings = {
       substituters = lib.mkAfter ["https://attic.xuyh0120.win/lantian"];


### PR DESCRIPTION
清理行为等价的冗余声明与描述：

- `modules/nixos/system/nix.nix`：删除与 NixOS 默认值相同的 `nix.package = pkgs.nix`，移除随之闲置的 `pkgs` 参数
- `modules/common/nix.nix`：删除 `builders-use-substitutes`——仓库未配置任何 `buildMachines`，该设置不生效且易造成已有远程构建的误解
- `modules/common/tools.nix`：删除与 Home Manager 默认值相同的 `nix-direnv.package`
- `modules/nixos/apps/{coder,postgresql}.nix`：修正 `mkEnableOption` 双 "Enable" 描述；coder 的 `after` / `requires` 两处相同条件的 `mkIf` 合并为一处
- `modules/nixos/desktop/xdg-user-dirs.nix`：`publicShare` / `templates` 由指向 `/var/empty` 改为 `null`，直接不生成对应 XDG 变量
- `modules/nixos/desktop/applications.nix`：补充"基础应用集"的设计意图注释，说明带自身配置的应用走 `desktop'.apps.<app>` 独立模块
