### PR TITLE
feat(fcitx5): 集成 GTK 输入法支持

### DIFF
--- a/modules/nixos/desktop/fcitx5.nix
+++ b/modules/nixos/desktop/fcitx5.nix
@@ -18,6 +18,7 @@ in {
       fcitx5 = {
         waylandFrontend = true;
         addons = with pkgs; [
+          fcitx5-gtk
           fcitx5-rime
           (qt6Packages.fcitx5-configtool.override {kcmSupport = false;})
         ];


### PR DESCRIPTION
## 变更说明

- 为 Fcitx5 添加 `fcitx5-gtk`，支持 GTK 应用接入输入法

## 验证方式

- [x] `just check` 通过

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属和配置约定