### PR TITLE
feat(beelink): 添加 Niri 桌面环境

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -10,21 +10,39 @@
   ];
 
   services' = {
+    # Desktop support
+    accounts-daemon.enable = true;
+    gnome-keyring.enable = true;
+    pipewire.enable = true;
+    power-profiles-daemon.enable = true;
+    upower.enable = true;
+
+    # Storage and monitoring
     btrbk.enable = true;
     btrfs-scrub.enable = true;
-    coder = {
-      enable = true;
-      listenAddress = "0.0.0.0:34567";
-      accessUrl = "https://coder.in.ou.al";
-      wildcardAccessUrl = "*.coder.in.ou.al";
-      openFirewall = true;
-    };
-    networkmanager.enable = true;
-    openssh.enable = true;
-    postgresql.enable = true;
     smartd.enable = true;
     vnstat.enable = true;
     zram.enable = true;
+
+    # Network access
+    networkmanager.enable = true;
+    openssh.enable = true;
+  };
+
+  desktop' = {
+    # Applications
+    applications.enable = true;
+    apps.kitty.enable = true;
+
+    # Session and appearance
+    cursors.enable = true;
+    dms.enable = true;
+    fcitx5.enable = true;
+    fonts.enable = true;
+    greetd.enable = true;
+    niri.enable = true;
+    themes.enable = true;
+    xdg-user-dirs.enable = true;
   };
 
   security'.firewall.enable = true;

--- a/hosts/nixos/beelink/hardware.nix
+++ b/hosts/nixos/beelink/hardware.nix
@@ -29,8 +29,6 @@
     };
   };
 
-  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
-
   storage' = {
     disko = {
       enable = true;
@@ -40,4 +38,8 @@
     };
     persistence.enable = true;
   };
+
+  hardware'.amdgpu.enable = true;
+
+  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 }


### PR DESCRIPTION
## 变更说明

- 为 Beelink 启用 Niri、Greetd/Tuigreet 和 DankMaterialShell
- 启用 Fcitx5 输入法、字体、主题、光标、XDG 用户目录和 Kitty
- 启用桌面所需的音频、电源、密钥环和 AccountsService
- 启用 AMD GPU 支持
- 按类别整理 Beelink 主机配置并调整服务清单

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定