### PR TITLE
feat(beelink): 启用 Visual Studio Code

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -33,6 +33,7 @@
     # Applications
     applications.enable = true;
     apps.kitty.enable = true;
+    apps.vscode.enable = true;
 
     # Session and appearance
     cursors.enable = true;


### PR DESCRIPTION
## 变更说明

- 为 Beelink 主机启用 Visual Studio Code
- 复用现有桌面 VS Code 模块及其持久化配置

## 验证方式

- `alejandra --check hosts/nixos/beelink/default.nix`
- `deadnix --fail .`

当时 `nix flake check --no-build` 无法连接本地 Lix 守护进程套接字。
