### PR TITLE
fix(fcitx5): 配置 Rime 输入法

### DIFF
--- a/modules/nixos/desktop/fcitx5.nix
+++ b/modules/nixos/desktop/fcitx5.nix
@@ -25,6 +25,14 @@ in {
       };
     };
 
+    # Keep the input method group declarative. Fcitx5 rewrites this file when
+    # input methods are changed at runtime, so force the desired profile back
+    # during every Home Manager activation.
+    hm'.xdg.configFile."fcitx5/profile" = {
+      source = ./fcitx5/profile;
+      force = true;
+    };
+
     preservation'.user.directories = [
       # Fcitx5
       ".config/fcitx5"

--- a/modules/nixos/desktop/fcitx5/profile
+++ b/modules/nixos/desktop/fcitx5/profile
@@ -1,0 +1,22 @@
+[Groups/0]
+# Group Name
+Name=Default
+# Layout
+Default Layout=us
+# Default Input Method
+DefaultIM=rime
+
+[Groups/0/Items/0]
+# Name
+Name=keyboard-us
+# Layout
+Layout=
+
+[Groups/0/Items/1]
+# Name
+Name=rime
+# Layout
+Layout=
+
+[GroupOrder]
+0=Default


### PR DESCRIPTION
## 变更说明

- 通过 Home Manager 声明式管理 Fcitx5 profile
- 在美式键盘之外启用 Rime 作为默认输入法
- 激活时强制写入 profile，防止持久化的运行时改动移除 Rime

## 验证方式

- `alejandra --check modules/nixos/desktop/fcitx5.nix`
- `deadnix --fail .`
- `nix-instantiate --parse modules/nixos/desktop/fcitx5.nix`
