### PR TITLE
feat(tang): 支持配置监听端口

### DIFF
--- a/modules/nixos/apps/tang.nix
+++ b/modules/nixos/apps/tang.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.services'.tang;
+in {
+  options.services'.tang = {
+    enable = lib.mkEnableOption "Tang key derivation service";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 7654;
+      description = "TCP port on which Tang listens";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.tang = {
+      enable = true;
+      listenStream = [(toString cfg.port)];
+      ipAddressAllow = ["0.0.0.0/0"];
+    };
+
+    networking.firewall.allowedTCPPorts = [cfg.port];
+  };
+}


### PR DESCRIPTION
## 变更说明

- 新增可配置的 `services'.tang.port`，默认 7654
- Tang 监听与防火墙规则均使用配置的端口

## 验证方式

- `alejandra --check modules/nixos/apps/tang.nix`
- `deadnix --fail .`

本 PR 仅包含 Tang 模块改动，其他本地改动不在其中。
