### PR TITLE
feat(fail2ban): 新增 ignoreIP 选项并将封禁上限延长至一周

### DIFF
--- a/modules/nixos/services/fail2ban.nix
+++ b/modules/nixos/services/fail2ban.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.services'.fail2ban;
+in {
+  options.services'.fail2ban = {
+    enable = lib.mkEnableOption "fail2ban service";
+
+    ignoreIP = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = ''
+        IP addresses, CIDR masks or DNS hosts that fail2ban will never ban,
+        for trusted networks such as a VPN or office range.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.fail2ban = {
+      enable = true;
+      ignoreIP = cfg.ignoreIP;
+      bantime = "1h";
+      bantime-increment = {
+        enable = true;
+        maxtime = "1w";
+        rndtime = "10m";
+      };
+    };
+
+    preservation'.os.directories = ["/var/lib/fail2ban"];
+  };
+}


### PR DESCRIPTION
## 改动

`services'.fail2ban` 新增 `ignoreIP` 透传选项（`listOf str`，默认空），主机可按需配置可信网段（VPN、办公网段等）避免误封；封禁上限 `maxtime` 从 24h 提高到 1w，公网机器上累犯更早触顶。

解封与累犯计数说明：`fail2ban-client unban <IP>` 会同时清除 nftables 封禁规则和数据库里的 `bans`/`bips`（前科）记录，`maxtime` 只是增长上限，不影响手动洗白。

## 验证

- `alejandra --check .`、`deadnix --fail .` 通过
- `nix flake check --all-systems --no-build` 及 darwin 求值通过（含 `bjs-ali-01`）