### PR TITLE
feat(persistence): 保留动态用户的 /var/lib/private

### DIFF
--- a/modules/nixos/storage/persistence.nix
+++ b/modules/nixos/storage/persistence.nix
@@ -74,6 +74,11 @@ in {
         }
         "/var/lib/lastlog"
         "/var/lib/systemd"
+        {
+          # Systemd-managed state of dynamic users (StateDirectory services).
+          directory = "/var/lib/private";
+          mode = "0700";
+        }
         "/var/log"
         {
           directory = "/var/tmp";


### PR DESCRIPTION
## 变更说明

- 保留 `/var/lib/private`（mode 0700）：systemd 会把动态用户服务的 `StateDirectory=` 重定向到这里，否则 ephemeral root 重启后这类服务状态会丢失

## 验证方式

- `alejandra --check .` / `deadnix --fail .` 通过
- `nix flake check --all-systems --no-build` 求值 beelink、elaina、router
