### PR TITLE
feat(disable-balloon): 屏蔽 virtio_balloon

### DIFF
--- a/modules/nixos/system/disable-balloon.nix
+++ b/modules/nixos/system/disable-balloon.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  cfg = config.hardware'.disable-balloon;
+in {
+  options.hardware'.disable-balloon = {
+    enable = lib.mkEnableOption "Disable virtio_balloon module";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.extraModprobeConfig = ''
+      blacklist virtio_balloon
+      install virtio_balloon ${pkgs.coreutils}/bin/true
+    '';
+  };
+}


### PR DESCRIPTION
## 变更说明

- 新增 `hardware'.disable-balloon.enable` 开关，通过 modprobe（`blacklist` + `install ... true`）屏蔽 `virtio_balloon` 模块，防止超售的 VPS 宿主机通过 balloon 回收客户机内存
- 未启用时不产生任何配置

## 验证方式

- `alejandra --check .` / `deadnix --fail .` 通过
- `nix flake check --all-systems --no-build` 求值 beelink、elaina、router
