### PR TITLE
feat(qemu): 新增客户机 initrd 模块

### DIFF
--- a/modules/nixos/system/qemu.nix
+++ b/modules/nixos/system/qemu.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.hardware'.qemu;
+in {
+  options.hardware'.qemu = {
+    enable = lib.mkEnableOption "QEMU initrd configuration";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.initrd = {
+      availableKernelModules = [
+        "virtio_blk"
+        "virtio_mmio"
+        "virtio_net"
+        "virtio_pci"
+        "virtio_scsi"
+      ];
+
+      kernelModules = [
+        "virtio_console"
+        "virtio_rng"
+      ];
+
+      compressor = "zstd";
+      compressorArgs = [
+        "-19"
+        "-T0"
+      ];
+
+      systemd.enable = true;
+    };
+  };
+}


### PR DESCRIPTION
## 变更说明

- 新增 `hardware'.qemu.enable` 开关，面向 QEMU/KVM 客户机：initrd 加入 virtio 内核模块（`virtio_blk/mmio/net/pci/scsi` 及 `virtio_console`/`virtio_rng`）、zstd initrd 压缩、systemd initrd
- 刻意不加载 `virtio_balloon`，与 disable-balloon 模块配合
- 未启用时不产生任何配置

## 验证方式

- `alejandra --check .` / `deadnix --fail .` 通过
- `nix flake check --all-systems --no-build` 求值 beelink、elaina、router
