### PR TITLE
feat(grub): 新增支持 BIOS 与 UEFI 的模块

### DIFF
--- a/modules/nixos/system/grub.nix
+++ b/modules/nixos/system/grub.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.boot'.grub;
+  diskoCfg = config.storage'.disko;
+in {
+  options.boot'.grub = {
+    enable = lib.mkEnableOption "GRUB bootloader";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.loader.grub = {
+      enable = lib.mkDefault true;
+      efiSupport = lib.mkDefault true;
+      configurationLimit = lib.mkDefault 5;
+      efiInstallAsRemovable = lib.mkDefault true;
+    };
+
+    # A BIOS boot partition (storage'.disko.bios.enable) means the machine
+    # boots via legacy BIOS and GRUB must also be installed onto the disk
+    # itself; the ESP stays populated as a fallback. Without it, GRUB
+    # installs EFI-only.
+    boot.loader.grub.device = lib.mkIf diskoCfg.bios.enable (
+      lib.mkDefault diskoCfg.device
+    );
+  };
+}


### PR DESCRIPTION
## 变更说明

- 新增 `boot'.grub.enable` 开关
- UEFI 主机（默认）：仅经 ESP 可移动路径安装（`efiInstallAsRemovable`）
- BIOS 主机：设置 `storage'.disko.bios.enable`（共享 disko 布局的 1 MiB EF02 分区）时，`boot.loader.grub.device` 自动设为 disko 目标盘，GRUB 额外支持传统 BIOS 引导；ESP 仍保留为回退
- 一个开关同时决定分区布局与安装器行为，不引入重复开关

## 验证方式

- `alejandra --check .` / `deadnix --fail .` 通过
- `nix flake check --all-systems --no-build` 求值 beelink、elaina、router
- 临时主机求值：BIOS 路径将 `boot.loader.grub.device` 设为 disko 目标盘，UEFI 路径保持为空（仅 EFI）
