### PR TITLE
feat(initrd-ssh): 支持远程解锁 LUKS

### DIFF
--- a/modules/nixos/system/initrd-ssh.nix
+++ b/modules/nixos/system/initrd-ssh.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.boot'.initrd-ssh;
+in {
+  options.boot'.initrd-ssh = {
+    enable = lib.mkEnableOption "SSH in initrd";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 22;
+      description = "SSH port for initrd";
+    };
+
+    hostKeys = lib.mkOption {
+      type = lib.types.listOf (lib.types.either lib.types.str lib.types.path);
+      default = ["/etc/secrets/initrd/id_ed25519"];
+      description = "Host keys for initrd SSH";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.initrd.network = {
+      enable = true;
+      ssh = {
+        enable = true;
+        inherit (cfg) port hostKeys;
+      };
+    };
+
+    boot.initrd.systemd.users.root.shell = "/bin/systemd-tty-ask-password-agent";
+
+    preservation'.os.directories = ["/etc/secrets/initrd"];
+  };
+}


### PR DESCRIPTION
## 变更说明

- 新增 `boot'.initrd-ssh.enable` 开关：在 initrd 阶段通过 SSH 远程解锁 LUKS
- 端口可配置（默认 22），主机密钥可配置（默认 `/etc/secrets/initrd/id_ed25519`，经 preservation 持久化，重启保留）
- 授权密钥沿用 `users.users.root.openssh.authorizedKeys`（NixOS 默认行为），`core'` 已从 vars 填充
- initrd 的 root shell 设为 `systemd-tty-ask-password-agent`，SSH 登录后直接出现 LUKS 密码提示
- 未启用时不产生任何配置

## 验证方式

- `alejandra --check .` / `deadnix --fail .` 通过
- `nix flake check --all-systems --no-build` 求值 beelink、elaina、router
