### PR TITLE
feat(tang): 支持配置来源 IP 白名单

### DIFF
--- a/modules/nixos/apps/tang.nix
+++ b/modules/nixos/apps/tang.nix
@@ -13,13 +13,22 @@ in {
       default = 7654;
       description = "TCP port on which Tang listens";
     };
+
+    ipAddressAllow = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = ["0.0.0.0/0"];
+      description = ''
+        Source addresses (IPs or CIDR prefixes) allowed to reach Tang,
+        applied by upstream as a systemd socket whitelist.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     services.tang = {
       enable = true;
       listenStream = [(toString cfg.port)];
-      ipAddressAllow = ["0.0.0.0/0"];
+      ipAddressAllow = cfg.ipAddressAllow;
     };
 
     networking.firewall.allowedTCPPorts = [cfg.port];


### PR DESCRIPTION
## 变更说明

- 新增 `services'.tang.ipAddressAllow`（`listOf str`，默认 `["0.0.0.0/0"]`），直通上游 `services.tang.ipAddressAllow`
- 上游以 `IPAddressDeny = "any"` + `IPAddressAllow` 组成 systemd socket 级来源白名单，该选项此前被硬编码为全放行，现可按网段收紧（如 `["192.168.1.0/24"]`）
- 默认值与原行为完全一致；未启用 tang 的主机不受影响

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定