### PR TITLE
refactor(boot): 完善 GRUB 模块并为 systemd-boot 增加仓库开关

### DIFF
--- a/hosts/nixos/beelink/hardware.nix
+++ b/hosts/nixos/beelink/hardware.nix
@@ -22,12 +22,9 @@
 
     kernelModules = ["kvm-amd"];
     kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest-lto-x86_64-v3;
-
-    loader = {
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
-    };
   };
+
+  boot'.systemd-boot.enable = true;
 
   storage' = {
     disko = {

--- a/hosts/nixos/elaina/hardware.nix
+++ b/hosts/nixos/elaina/hardware.nix
@@ -22,12 +22,9 @@
 
     kernelModules = ["kvm-amd"];
     kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest-lto-zen4;
-
-    loader = {
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
-    };
   };
+
+  boot'.systemd-boot.enable = true;
 
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 

--- a/hosts/nixos/router/hardware.nix
+++ b/hosts/nixos/router/hardware.nix
@@ -14,12 +14,9 @@
     kernelParams = ["audit=0" "net.ifnames=0"];
 
     initrd.availableKernelModules = ["uhci_hcd" "ehci_pci" "ahci" "virtio_pci" "virtio_scsi" "sd_mod" "sr_mod"];
-
-    loader = {
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
-    };
   };
+
+  boot'.systemd-boot.enable = true;
 
   # PVE uses the guest agent for clean shutdown and IP reporting.
   services.qemuGuest.enable = true;

--- a/modules/nixos/boot/grub.nix
+++ b/modules/nixos/boot/grub.nix
@@ -11,19 +11,37 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    boot.loader.grub = {
-      enable = lib.mkDefault true;
-      efiSupport = lib.mkDefault true;
-      configurationLimit = lib.mkDefault 5;
-      efiInstallAsRemovable = lib.mkDefault true;
-    };
+    # The two bootloaders are mutually exclusive; upstream does not enforce
+    # this, so the repo-level switches have to.
+    assertions = [
+      {
+        assertion = !config.boot'.systemd-boot.enable;
+        message = "boot'.grub and boot'.systemd-boot are mutually exclusive; enable only one.";
+      }
+    ];
 
-    # A BIOS boot partition (storage'.disko.bios.enable) means the machine
-    # boots via legacy BIOS and GRUB must also be installed onto the disk
-    # itself; the ESP stays populated as a fallback. Without it, GRUB
-    # installs EFI-only.
-    boot.loader.grub.device = lib.mkIf diskoCfg.bios.enable (
-      lib.mkDefault diskoCfg.device
-    );
+    boot.loader.grub = {
+      enable = true;
+      efiSupport = lib.mkDefault true;
+      # Removable install boots via the fallback \EFI\BOOT path, so firmware
+      # never needs an NVRAM entry — and upstream forbids pairing this with
+      # boot.loader.efi.canTouchEfiVariables anyway.
+      efiInstallAsRemovable = lib.mkDefault true;
+      configurationLimit = lib.mkDefault 8;
+
+      # With a BIOS boot partition (storage'.disko.bios.enable) GRUB also
+      # installs onto the disk itself, with the ESP staying populated as a
+      # fallback; pure UEFI hosts install nothing but the removable EFI
+      # binary, which upstream expresses as the special device "nodev".
+      device = lib.mkDefault (
+        if diskoCfg.bios.enable
+        then diskoCfg.device
+        else "nodev"
+      );
+
+      # Kernels live in the Nix store on the encrypted btrfs root, so GRUB
+      # must open the LUKS container itself before loading them.
+      enableCryptodisk = lib.mkIf diskoCfg.luks.enable (lib.mkDefault true);
+    };
   };
 }

--- a/modules/nixos/boot/systemd-boot.nix
+++ b/modules/nixos/boot/systemd-boot.nix
@@ -1,7 +1,40 @@
-{lib, ...}: {
-  boot.loader.systemd-boot = {
-    editor = lib.mkDefault false;
-    consoleMode = lib.mkDefault "max";
-    configurationLimit = lib.mkDefault 8;
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.boot'.systemd-boot;
+  diskoCfg = config.storage'.disko;
+in {
+  options.boot'.systemd-boot = {
+    enable = lib.mkEnableOption "systemd-boot bootloader with EFI variable management";
+  };
+
+  config = lib.mkIf cfg.enable {
+    # systemd-boot is UEFI-only, so a BIOS boot partition would be dead
+    # weight; BIOS hosts should use boot'.grub instead.
+    assertions = [
+      {
+        assertion = !diskoCfg.bios.enable;
+        message = "boot'.systemd-boot cannot be combined with storage'.disko.bios.enable; use boot'.grub for BIOS boot.";
+      }
+      {
+        assertion = !config.boot'.grub.enable;
+        message = "boot'.grub and boot'.systemd-boot are mutually exclusive; enable only one.";
+      }
+    ];
+
+    boot.loader = {
+      systemd-boot = {
+        enable = true;
+        editor = lib.mkDefault false;
+        consoleMode = lib.mkDefault "max";
+        configurationLimit = lib.mkDefault 8;
+      };
+
+      # bootctl registers the "Linux Boot Manager" NVRAM entry on install;
+      # this shared EFI-layer option is what allows it to do so.
+      efi.canTouchEfiVariables = true;
+    };
   };
 }


### PR DESCRIPTION
## 变更说明

- `grub.nix`：补 `enableCryptodisk`（LUKS 开启时内核位于加密 btrfs 内，GRUB 须自解密才能加载）；纯 UEFI 主机按上游约定 `device = "nodev"`，修复缺 device 的求值断言；新增与 `boot'.systemd-boot` 的互斥断言（上游未拦截）；`enable` 改普通赋值避免 mkDefault 优先级冲突；合并两处 `boot.loader.grub` 块；generation 上限对齐 systemd-boot 为 8
- `systemd-boot.nix`：新增 `boot'.systemd-boot.enable` 仓库开关，收编 `boot.loader.systemd-boot.enable` 与 `efi.canTouchEfiVariables`；断言不可与 `storage'.disko.bios.enable` 组合（systemd-boot 仅 UEFI）
- elaina / beelink / router 的 hardware.nix 改用 `boot'.systemd-boot.enable`，移除手写裸上游选项，行为零变化
- 两个模块结构统一：options 开关 → assertions 守卫 → 底层配置（mkDefault 调优）

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定