### PR TITLE
refactor(ssh): 加固 openssh、完善 initrd-ssh 并调整端口默认值

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -26,6 +26,7 @@
     # Network access
     networkmanager.enable = true;
     openssh.enable = true;
+    openssh.port = 233;
   };
 
   desktop' = {

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -15,6 +15,7 @@
     gnome-keyring.enable = true;
     networkmanager.enable = true;
     openssh.enable = true;
+    openssh.port = 233;
     pipewire.enable = true;
     power-profiles-daemon.enable = true;
     printing.enable = true;

--- a/hosts/nixos/router/default.nix
+++ b/hosts/nixos/router/default.nix
@@ -19,6 +19,7 @@
 
   services' = {
     openssh.enable = true;
+    openssh.port = 233;
     vnstat.enable = true;
     zram.enable = true;
   };

--- a/modules/nixos/boot/initrd-ssh.nix
+++ b/modules/nixos/boot/initrd-ssh.nix
@@ -6,7 +6,11 @@
   cfg = config.boot'.initrd-ssh;
 in {
   options.boot'.initrd-ssh = {
-    enable = lib.mkEnableOption "SSH in initrd";
+    enable = lib.mkEnableOption ''
+      SSH in initrd for remote LUKS unlock. The host must ensure its NIC
+      driver (e.g. r8169, igc, virtio_net) is present in
+      boot.initrd.availableKernelModules, or the initrd will have no network.
+    '';
 
     port = lib.mkOption {
       type = lib.types.port;
@@ -27,10 +31,12 @@ in {
       ssh = {
         enable = true;
         inherit (cfg) port hostKeys;
+
+        # Show the LUKS passphrase prompt inside the SSH session instead of
+        # a plain shell.
+        shell = "/bin/systemd-tty-ask-password-agent";
       };
     };
-
-    boot.initrd.systemd.users.root.shell = "/bin/systemd-tty-ask-password-agent";
 
     preservation'.os.directories = ["/etc/secrets/initrd"];
   };

--- a/modules/nixos/services/openssh.nix
+++ b/modules/nixos/services/openssh.nix
@@ -10,7 +10,7 @@ in {
 
     port = lib.mkOption {
       type = lib.types.port;
-      default = 233;
+      default = 22;
       description = "TCP port on which OpenSSH listens";
     };
 
@@ -25,10 +25,23 @@ in {
     services.openssh = {
       enable = true;
       ports = [cfg.port];
+
+      # Only the Ed25519 host identity is needed; upstream also generates
+      # an RSA key by default.
+      hostKeys = lib.mkDefault [
+        {
+          path = "/etc/ssh/ssh_host_ed25519_key";
+          type = "ed25519";
+        }
+      ];
+
       settings = {
         # root user is used for remote deployment, so we need to allow it
         PermitRootLogin = lib.mkDefault "prohibit-password";
         PasswordAuthentication = lib.mkDefault false;
+        # Without this, keyboard-interactive still reaches the PAM password
+        # prompt and defeats the key-only intent above.
+        KbdInteractiveAuthentication = lib.mkDefault false;
       };
       openFirewall = cfg.openFirewall;
     };


### PR DESCRIPTION
## 变更说明

- openssh 加固：`KbdInteractiveAuthentication = false` 封堵 keyboard-interactive 经 PAM 的密码路径——此前仅关 `PasswordAuthentication` 时密码登录仍是半开状态，现在密钥成为唯一登录方式
- host key 仅保留 Ed25519（上游默认还会生成一把多余的 RSA 4096）
- 端口默认值回归标准的 22；elaina / beelink / router 在主机配置中以两行显式声明 `openssh.enable` / `openssh.port = 233`，实际监听端口不变（三台主机求值验证均为 `[233]`）
- initrd-ssh：改用上游 `boot.initrd.network.ssh.shell` 选项在 SSH 会话内展示 LUKS 密码提示，替代直接修改 initrd root shell；`enable` 描述补充「主机需将网卡驱动加入 `boot.initrd.availableKernelModules`」的前提
- 登录公钥不受影响：initrd ssh 默认继承 root 的 authorizedKeys（来自 vars）

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定