### PR TITLE
perf(qemu): 去掉过度的 initrd zstd 压缩参数

### DIFF
--- a/modules/nixos/hardware/qemu.nix
+++ b/modules/nixos/hardware/qemu.nix
@@ -24,12 +24,6 @@ in {
         "virtio_rng"
       ];
 
-      compressor = "zstd";
-      compressorArgs = [
-        "-19"
-        "-T0"
-      ];
-
       systemd.enable = true;
     };
   };


### PR DESCRIPTION
## 变更说明

- 移除 `boot.initrd.compressor` / `compressorArgs`（`-19 -T0`）：上游对 5.9+ 内核默认压缩器已是 zstd，声明冗余；`-19` 为归档级压缩，每次 rebuild 都要数分钟重压 initrd，仅换来十几 MB 体积差
- 移除后回落默认压缩档（3），initrd 体积几乎不变，构建明显提速

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定