### PR TITLE
feat(desktop): 集成 keyring PAM 并开启 niri 自动登录

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -40,6 +40,7 @@
     fcitx5.enable = true;
     fonts.enable = true;
     greetd.enable = true;
+    niri.autoLogin = true;
     niri.enable = true;
     themes.enable = true;
     xdg-user-dirs.enable = true;

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -36,6 +36,7 @@
     fcitx5.enable = true;
     fonts.enable = true;
     greetd.enable = true;
+    niri.autoLogin = true;
     niri.enable = true;
     themes.enable = true;
     xdg-user-dirs.enable = true;

--- a/modules/nixos/desktop/session/gnome-keyring.nix
+++ b/modules/nixos/desktop/session/gnome-keyring.nix
@@ -14,7 +14,17 @@ in {
 
     # Seahorse is the keyring's GUI front-end and is useless on its own,
     # so it follows the same switch.
+    # Pitfall: never create a "Default keyring" in Seahorse — PAM only
+    # unlocks the "login" keyring, so a second default keyring would fork
+    # secrets into a container that never syncs with the login password.
     programs.seahorse.enable = lib.mkIf cfg.enable true;
+
+    # Unlock the login keyring at greetd login, and keep it in sync when
+    # the login password changes via passwd — without these, Secret
+    # Service clients (gh, browsers) keep asking for a separate keyring
+    # password.
+    security.pam.services.greetd.enableGnomeKeyring = true;
+    security.pam.services.passwd.enableGnomeKeyring = true;
 
     # Niri can also enable the native service, so follow its final state.
     preservation'.user.directories = lib.optionals config.services.gnome.gnome-keyring.enable [


### PR DESCRIPTION
## 变更说明

- gnome-keyring 模块新增 PAM 集成：`security.pam.services.greetd/passwd` 的 `enableGnomeKeyring`，登录时解锁 login 密钥环、改密后自动同步，Secret Service 客户端（gh、浏览器）不再反复索要独立密钥环密码
- seahorse 注释标明 pitfall：不可新建 "Default keyring"（PAM 只解锁 login 环，第二个环会分叉出永不同步的密码）
- elaina / beelink 开启 `niri.autoLogin`：解锁 LUKS 后直接进入桌面，无需二次登录
- ⚠️ 自动登录不经 PAM：启用后需在 seahorse 中将 login 密钥环密码改为空（一次性），否则每次登录后首次访问密钥环仍会弹解锁框

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定