### PR TITLE
feat(security): 新增内核加固与 ARP 反欺骗模块

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Justfile              switch / check / update / gc / fmt 等常用命令
 | `services'` | 主机级系统服务（含 PostgreSQL） | `modules/nixos/services/`、`modules/nixos/apps/`、`modules/nixos/desktop/session/`、`modules/nixos/storage/` |
 | `desktop'` | 桌面功能与应用开关 | `modules/nixos/desktop/` |
 | `hardware'` | 可选硬件支持 | `modules/nixos/hardware/` |
-| `security'` | 安全功能（firewall、touch-id） | `modules/nixos/security/`、`modules/darwin/security/` |
+| `security'` | 安全功能（firewall、kernel-hardening、arp-filter、touch-id） | `modules/nixos/security/`、`modules/darwin/security/` |
 | `storage'` | 磁盘与持久化（disko、persistence） | `modules/nixos/storage/` |
 | `preservation'` | Preservation 选项别名，`os` / `user` 对应 `/persistent` 下的系统与用户条目 | `modules/nixos/storage/persistence.nix` |
 | `persist'` | 纯 Home Manager 工具上报的持久化条目 | `home/common/persist.nix` |

--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -46,6 +46,7 @@
   };
 
   security'.firewall.enable = true;
+  security'.kernel-hardening.enable = true;
 
   tools'.dev.enable = true;
 

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -42,6 +42,7 @@
   };
 
   security'.firewall.enable = true;
+  security'.kernel-hardening.enable = true;
 
   tools'.dev.enable = true;
 

--- a/hosts/nixos/router/default.nix
+++ b/hosts/nixos/router/default.nix
@@ -25,6 +25,7 @@
   };
 
   security'.firewall.enable = true;
+  security'.kernel-hardening.enable = true;
 
   system.stateVersion = "26.05";
 }

--- a/modules/nixos/security/arp-filter.nix
+++ b/modules/nixos/security/arp-filter.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.security'.arp-filter;
+in {
+  options.security'.arp-filter = {
+    enable = lib.mkEnableOption ''
+      nftables ARP anti-spoofing: on the selected interfaces, ARP packets
+      advertising a source address outside the allowed prefixes are dropped.
+      Intended for hosts on shared L2 segments, such as cloud servers with
+      public IPv4/IPv6.
+    '';
+
+    interfaces = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = "Interfaces on which ARP traffic is filtered";
+    };
+
+    allowedSubnets = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = ''
+        Source IP prefixes accepted in ARP on the protected interfaces,
+        typically the host's own subnet. An empty list drops every ARP
+        packet on those interfaces.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.nftables.enable = lib.mkDefault true;
+
+    networking.nftables.tables.arp-filter = {
+      family = "arp";
+      content = let
+        # An empty set is invalid nft syntax, so a dummy prefix matching no
+        # real traffic stands in for "block everything".
+        subnets =
+          if cfg.allowedSubnets == []
+          then ["0.0.0.0/32"]
+          else cfg.allowedSubnets;
+      in ''
+        chain input {
+          type filter hook input priority 0; policy accept;
+          ${lib.concatMapStringsSep "\n" (iface: ''
+            iifname "${iface}" arp saddr ip != { ${lib.concatStringsSep ", " subnets} } drop
+          '')
+          cfg.interfaces}
+        }
+
+        chain output {
+          type filter hook output priority 0; policy accept;
+          ${lib.concatMapStringsSep "\n" (iface: ''
+            oifname "${iface}" arp daddr ip != { ${lib.concatStringsSep ", " subnets} } drop
+          '')
+          cfg.interfaces}
+        }
+      '';
+    };
+  };
+}

--- a/modules/nixos/security/kernel-hardening.nix
+++ b/modules/nixos/security/kernel-hardening.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}: let
+  cfg = config.security'.kernel-hardening;
+in {
+  options.security'.kernel-hardening = {
+    enable = lib.mkEnableOption ''
+      kernel module blacklist mitigating the Dirty Frag LPE (esp4, esp6,
+      rxrpc). Harmless unless IPsec ESP or AF_RXRPC is actually used.
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.blacklistedKernelModules = ["esp4" "esp6" "rxrpc"];
+
+    boot.extraModprobeConfig = ''
+      install esp4 ${pkgs.coreutils}/bin/false
+      install esp6 ${pkgs.coreutils}/bin/false
+      install rxrpc ${pkgs.coreutils}/bin/false
+    '';
+  };
+}

--- a/modules/nixos/services/openssh.nix
+++ b/modules/nixos/services/openssh.nix
@@ -39,9 +39,13 @@ in {
         # root user is used for remote deployment, so we need to allow it
         PermitRootLogin = lib.mkDefault "prohibit-password";
         PasswordAuthentication = lib.mkDefault false;
-        # Without this, keyboard-interactive still reaches the PAM password
-        # prompt and defeats the key-only intent above.
+        # Closing the keyboard-interactive channel leaves publickey as the
+        # only authentication method, no matter how the PAM stack is
+        # composed (older nixpkgs let the unix password through here, and
+        # any future PAM module like OTP would also ride this channel).
         KbdInteractiveAuthentication = lib.mkDefault false;
+        # Pure Wayland hosts gain nothing from X11 forwarding.
+        X11Forwarding = lib.mkDefault false;
       };
       openFirewall = cfg.openFirewall;
     };


### PR DESCRIPTION
## 变更说明

- 新增 `security'.kernel-hardening`：黑名单 `esp4`/`esp6`/`rxrpc`（modprobe install 拦截），缓解 Dirty Frag 本地提权；elaina / beelink / router 全部启用。代价仅为不使用 IPsec ESP / AF_RXRPC 时无感
- 新增 `security'.arp-filter`（休眠模块）：基于声明式 `networking.nftables.tables`（arp family）的来源地址白名单，输入/输出双向过滤选定接口上宣称未知网段的 ARP 包，防共享 L2 场景（云服务器）邻居欺骗；`allowedSubnets` 为空时全拦
- openssh 显式 `X11Forwarding = false`（纯 Wayland 主机无需求）
- AGENTS.md 的 `security'` 命名空间描述同步

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定