### PR TITLE
refactor(services): 独立 avahi 模块并按实际使用调整主机服务

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -10,6 +10,8 @@
   ];
 
   services' = {
+    avahi.enable = true;
+
     # Desktop support
     gnome-keyring.enable = true;
     pipewire.enable = true;

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -10,6 +10,7 @@
   ];
 
   services' = {
+    avahi.enable = true;
     btrbk.enable = true;
     btrfs-scrub.enable = true;
     gnome-keyring.enable = true;
@@ -18,7 +19,6 @@
     openssh.port = 233;
     pipewire.enable = true;
     power-profiles-daemon.enable = true;
-    printing.enable = true;
     smartd.enable = true;
     upower.enable = true;
     vnstat.enable = true;

--- a/modules/nixos/services/avahi.nix
+++ b/modules/nixos/services/avahi.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  cfg = config.services'.avahi;
+in {
+  options.services'.avahi = {
+    enable = lib.mkEnableOption ''
+      Avahi mDNS/Zeroconf: resolve and publish .local hostnames on the LAN
+      (e.g. ssh <hostname>.local), and discover network printers for CUPS.
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.avahi = {
+      enable = true;
+      nssmdns4 = true;
+      openFirewall = true;
+
+      # Advertise this machine itself on the LAN, so peers can discover it
+      # and reach it at <hostname>.local without knowing its IP.
+      publish = {
+        enable = true;
+        domain = true;
+        userServices = true;
+      };
+    };
+  };
+}

--- a/modules/nixos/services/zram.nix
+++ b/modules/nixos/services/zram.nix
@@ -34,8 +34,9 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    # CachyOS enables zswap by default. Disable it to avoid putting a
-    # compressed cache in front of the compressed Zram swap device.
+    # Most kernels enable zswap by default (the NixOS default kernel is a
+    # notable exception). Disable it to avoid putting a compressed cache in
+    # front of the compressed Zram swap device.
     boot = {
       kernelParams = ["zswap.enabled=0"];
       kernel.sysctl."vm.swappiness" = 100;


### PR DESCRIPTION
## 变更说明

- 新增 `services'.avahi` 独立模块（`nssmdns4` + `openFirewall` + `publish` 广播主机名）——mDNS 是内网基础能力（`.local` 解析、设备发现），从 printing 中解耦出来
- elaina / beelink 启用 avahi：局域网内可直接访问 `elaina.local` / `beelink.local`
- elaina 移除 `printing.enable`（暂无打印机；printing 模块保留，日后加一行即可恢复）
- zram.nix 注释从 CachyOS 特指改为通用表述（多数内核默认开 zswap，NixOS 默认内核是例外），不绑定内核选择

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定