### PR TITLE
fix(boot): 限制 router 引导代数以适配 256M ESP

### DIFF
--- a/hosts/nixos/router/hardware.nix
+++ b/hosts/nixos/router/hardware.nix
@@ -17,6 +17,9 @@
   };
 
   boot'.systemd-boot.enable = true;
+  # The VM was installed with a 256M ESP; keep fewer generations so it does
+  # not fill up with LTO kernels (~50M per generation).
+  boot.loader.systemd-boot.configurationLimit = 4;
 
   # PVE uses the guest agent for clean shutdown and IP reporting.
   services.qemuGuest.enable = true;


### PR DESCRIPTION
## 变更说明

- router VM 安装时 ESP 为默认的 256M（`espSize` 未显式设置），而 systemd-boot 会把每代内核 + initrd 复制进 ESP（约 40-60M/代），`configurationLimit = 8` 保留 8 代迟早写满，导致 `nixos-rebuild` 在引导器安装阶段失败
- 该主机覆盖为保留 4 代（约 200-240M），控制在 ESP 容量以内
- 全局默认值与其余主机不受影响

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定