### PR TITLE
feat(system): 限制 journald 日志占用（2G 磁盘 + 256M 内存）

### DIFF
--- a/modules/nixos/system/journald.nix
+++ b/modules/nixos/system/journald.nix
@@ -1,0 +1,9 @@
+{lib, ...}: {
+  # Keep the persisted /var/log journal bounded instead of growing with the
+  # disk, bound the in-RAM early-boot journal as well; hosts with tighter
+  # constraints override this (e.g. router: 128M).
+  services.journald.extraConfig = lib.mkDefault ''
+    SystemMaxUse=2G
+    RuntimeMaxUse=256M
+  '';
+}


### PR DESCRIPTION
## 变更说明

- 新增 `modules/nixos/system/journald.nix` 基线：`SystemMaxUse=2G`（磁盘持久日志上限）+ `RuntimeMaxUse=256M`（开机早期内存日志上限，借鉴 ryan4yin 的监控服务器配置）
- 动机：`/var/log` 被 persistence 持久化，journald 默认可增长到文件系统的 10%（上限 4G），无界日志是慢性问题；存储模式为默认的 `persistent`，早期内存日志由 `systemd-journal-flush` 自动刷盘
- 使用 `mkDefault`：router 自己的 `SystemMaxUse=128M` 覆盖依然优先生效（已实测），其余主机获得基线上限

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定