### PR TITLE
feat(desktop): 启用 Noctalia 并持久化用户状态

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -44,6 +44,7 @@
     greetd.enable = true;
     niri.autoLogin = true;
     niri.enable = true;
+    noctalia.enable = true;
     themes.enable = true;
     xdg-user-dirs.enable = true;
   };

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -38,6 +38,7 @@
     greetd.enable = true;
     niri.autoLogin = true;
     niri.enable = true;
+    noctalia.enable = true;
     themes.enable = true;
     xdg-user-dirs.enable = true;
   };

--- a/modules/nixos/desktop/session/noctalia.nix
+++ b/modules/nixos/desktop/session/noctalia.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.desktop'.noctalia;
+in {
+  options.desktop'.noctalia = {
+    enable = lib.mkEnableOption "Noctalia desktop shell";
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.noctalia = {
+      enable = true;
+      systemd.enable = true;
+    };
+
+    # Keep Noctalia's GUI-managed configuration and runtime data across
+    # reboots while leaving all settings editable from its UI.
+    preservation'.user.directories = [
+      {
+        directory = ".config/noctalia";
+        mode = "0700";
+      }
+      {
+        directory = ".local/state/noctalia";
+        mode = "0700";
+      }
+      {
+        directory = ".local/share/noctalia";
+        mode = "0700";
+      }
+    ];
+  };
+}


### PR DESCRIPTION
在两个 Niri NixOS 主机启用 Noctalia，并持久化 .config/noctalia、.local/state/noctalia 与 .local/share/noctalia。保留 UI 调整，不生成声明式 config.toml。验证：alejandra --check、deadnix --fail、nix-instantiate --parse 已通过；nix flake check 因当前环境缺少 Lix daemon 未能执行。