### PR TITLE
feat(nixos): 迁移 AI 工具模块并加入 ZCode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ modules/
   nixos/hardware/     可选硬件支持
   nixos/security/     安全功能（firewall）
   nixos/services/     与桌面无关的系统服务（远程访问、网络、内存、打印）
-  nixos/apps/         应用级系统服务（如 PostgreSQL）
+  nixos/apps/         应用级系统服务（如 PostgreSQL）与用户工具集（如 AI 开发工具）
   nixos/desktop/      桌面：session/ 会话栈、apps/ 应用、environment/ 外观与输入
   nixos/storage/      Disko、Preservation 与存储维护（btrbk、scrub、smartd）
   darwin/system/      nix-darwin 系统配置
@@ -60,7 +60,7 @@ Justfile              switch / check / update / gc / fmt 等常用命令
 | `boot'` | 引导：GRUB、systemd-boot、initrd SSH | `modules/nixos/boot/` |
 | `system'` | 系统级杂项（darwin 系统偏好 `system'.defaults`） | `modules/darwin/system/` |
 | `apps'` | 应用级系统配置（darwin Homebrew `apps'.homebrew`） | `modules/darwin/apps/` |
-| `tools'` | 跨平台用户 CLI 工具分组（`tools'.dev`、`tools'.coding-agents`） | `modules/common/` |
+| `tools'` | 用户工具分组：跨平台开发 CLI（`tools'.dev`）、NixOS AI 开发工具（`tools'.ai`） | `modules/common/`、`modules/nixos/apps/` |
 | `services'` | 主机级系统服务（含 PostgreSQL） | `modules/nixos/services/`、`modules/nixos/apps/`、`modules/nixos/desktop/session/`、`modules/nixos/storage/` |
 | `desktop'` | 桌面功能与应用开关 | `modules/nixos/desktop/` |
 | `hardware'` | 可选硬件支持 | `modules/nixos/hardware/` |
@@ -97,7 +97,7 @@ Karabiner 配置位于 `home/darwin/apps/karabiner.nix`，不设独立开关：H
 
 桌面应用（Firefox、Kitty 等）的启用开关统一放在 `desktop'.apps.<app>.enable`，由 `modules/nixos/desktop/apps/` 下的应用模块定义，模块内部通过 `hm'` 设置 Home Manager 的原生选项。不要为单个用户应用在 Home Manager 里新建自定义命名空间。
 
-跨平台的开发 CLI 工具集（gh、lazygit、uv、direnv、Nix 工具链）由 `tools'.dev.enable` 控制，安装、集成和持久化配置收敛在 `modules/common/tools.nix`；Shell 专属的 `uv` / `uvx` 补全分别放在 `home/common/fish.nix` 和 `home/common/zsh.nix`，并按命令是否存在加载。Claude Code 和 Codex 由 `tools'.coding-agents.enable` 控制，配置收敛在 `modules/common/coding-agents.nix`。其他带开关的内容不放入 `home/common/` 基线。`just` 属于所有主机共用的基线工具，放在 `home/common/misc.nix`。XDG 用户目录是桌面能力，由 `desktop'.xdg-user-dirs.enable` 控制，不放进 `home/nixos/` 基线。
+跨平台的开发 CLI 工具集（gh、lazygit、uv、direnv、Nix 工具链）由 `tools'.dev.enable` 控制，安装、集成和持久化配置收敛在 `modules/common/tools.nix`；Shell 专属的 `uv` / `uvx` 补全分别放在 `home/common/fish.nix` 和 `home/common/zsh.nix`，并按命令是否存在加载。NixOS 的 AI 开发工具集（Claude Code、Codex、DeepSeek CLI 和 ZCode）由 `tools'.ai.enable` 控制，配置收敛在 `modules/nixos/apps/ai-tools.nix`；其中 DeepSeek CLI（`dsh`）和 ZCode 使用 `llm-agents` input 提供的包，持久化直接声明在 `preservation'.user` 下。其他带开关的内容不放入 `home/common/` 基线。`just` 属于所有主机共用的基线工具，放在 `home/common/misc.nix`。XDG 用户目录是桌面能力，由 `desktop'.xdg-user-dirs.enable` 控制，不放进 `home/nixos/` 基线。
 
 ## 多设备配置
 

--- a/hosts/darwin/luna/default.nix
+++ b/hosts/darwin/luna/default.nix
@@ -9,7 +9,6 @@
   security'.touch-id.enable = true;
   system'.defaults.enable = true;
 
-  tools'.coding-agents.enable = true;
   tools'.dev.enable = true;
 
   nixpkgs.hostPlatform = "aarch64-darwin";

--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -52,6 +52,7 @@
   security'.firewall.enable = true;
   security'.kernel-hardening.enable = true;
 
+  tools'.ai.enable = true;
   tools'.dev.enable = true;
 
   system.stateVersion = "26.05";

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -46,6 +46,7 @@
   security'.firewall.enable = true;
   security'.kernel-hardening.enable = true;
 
+  tools'.ai.enable = true;
   tools'.dev.enable = true;
 
   system.stateVersion = "26.05";

--- a/modules/nixos/apps/ai-tools.nix
+++ b/modules/nixos/apps/ai-tools.nix
@@ -5,11 +5,11 @@
   pkgs,
   ...
 }: let
-  cfg = config.tools'.coding-agents;
-  dsh = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.dsh;
+  cfg = config.tools'.ai;
+  agentPackages = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system};
 in {
-  options.tools'.coding-agents = {
-    enable = lib.mkEnableOption "AI coding agents";
+  options.tools'.ai = {
+    enable = lib.mkEnableOption "AI development tools";
   };
 
   config = lib.mkIf cfg.enable {
@@ -18,18 +18,22 @@ in {
     hm'.programs.claude-code.enable = true;
     hm'.programs.codex.enable = true;
 
-    hm'.home.packages = [dsh];
+    hm'.home.packages = with agentPackages; [
+      dsh
+      zcode
+    ];
 
     hm'.home.shellAliases = {
       cc = "claude --dangerously-skip-permissions";
       cx = "codex --dangerously-bypass-approvals-and-sandbox";
     };
 
-    hm'.persist' = {
+    preservation'.user = {
       directories = [
         ".claude"
         ".codex"
         ".dsh"
+        ".zcode"
       ];
 
       files = [


### PR DESCRIPTION
## 变更说明

将 AI 开发工具集限定到 NixOS，并加入 `llm-agents` 已锁定的 ZCode 3.10.2。Beelink、Elaina 启用后会安装 Claude Code、Codex、DeepSeek CLI 和 ZCode。

- 将 `modules/common/coding-agents.nix` 迁为 `modules/nixos/apps/ai-tools.nix`，开关由 `tools'.coding-agents.enable` 改为 `tools'.ai.enable`。
- 将持久化配置迁到模块自己的 `preservation'.user` 下，并补上 `.zcode` 目录。
- 移除 Luna 的旧开关；下次应用 macOS 配置后，此模块提供的 Claude Code、Codex、dsh 及 `cc` / `cx` 别名将不再安装。Homebrew 中已有的 ZCode 保持原配置。
- 同步更新 `AGENTS.md`；不修改 flake lock。

## 验证方式

- [x] `just check` 所含检查已分项通过：`alejandra --check .`、`deadnix --fail .`、`nix flake check --all-systems --no-build --no-write-lock-file`，以及全部 Darwin 主机的 `system.drvPath` 求值。
- [x] `git diff --cached --check` 通过。

主机求值在包含完整工作区文件的临时非 Git 副本中运行。未执行系统构建、切换或 Linux 图形界面运行验证。

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定。
