### PR TITLE
feat(nixos): 添加 ChatGPT 桌面端

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Karabiner 配置位于 `home/darwin/apps/karabiner.nix`，不设独立开关：H
 
 桌面应用（Firefox、Kitty 等）的启用开关统一放在 `desktop'.apps.<app>.enable`，由 `modules/nixos/desktop/apps/` 下的应用模块定义，模块内部通过 `hm'` 设置 Home Manager 的原生选项。不要为单个用户应用在 Home Manager 里新建自定义命名空间。
 
-跨平台的开发 CLI 工具集（gh、lazygit、uv、direnv、Nix 工具链）由 `tools'.dev.enable` 控制，安装、集成和持久化配置收敛在 `modules/common/tools.nix`；Shell 专属的 `uv` / `uvx` 补全分别放在 `home/common/fish.nix` 和 `home/common/zsh.nix`，并按命令是否存在加载。NixOS 的 AI 开发工具集（Claude Code、Codex、DeepSeek CLI 和 ZCode）由 `tools'.ai.enable` 控制，配置收敛在 `modules/nixos/apps/ai-tools.nix`；其中 DeepSeek CLI（`dsh`）和 ZCode 使用 `llm-agents` input 提供的包，持久化直接声明在 `preservation'.user` 下。其他带开关的内容不放入 `home/common/` 基线。`just` 属于所有主机共用的基线工具，放在 `home/common/misc.nix`。XDG 用户目录是桌面能力，由 `desktop'.xdg-user-dirs.enable` 控制，不放进 `home/nixos/` 基线。
+跨平台的开发 CLI 工具集（gh、lazygit、uv、direnv、Nix 工具链）由 `tools'.dev.enable` 控制，安装、集成和持久化配置收敛在 `modules/common/tools.nix`；Shell 专属的 `uv` / `uvx` 补全分别放在 `home/common/fish.nix` 和 `home/common/zsh.nix`，并按命令是否存在加载。NixOS 的 AI 开发工具集（ChatGPT 桌面端、Claude Code、Codex、DeepSeek CLI 和 ZCode）由 `tools'.ai.enable` 控制，配置收敛在 `modules/nixos/apps/ai-tools.nix`；其中 ChatGPT（`chatgpt`）、DeepSeek CLI（`dsh`）和 ZCode 使用 `llm-agents` input 提供的包，持久化直接声明在 `preservation'.user` 下。其他带开关的内容不放入 `home/common/` 基线。`just` 属于所有主机共用的基线工具，放在 `home/common/misc.nix`。XDG 用户目录是桌面能力，由 `desktop'.xdg-user-dirs.enable` 控制，不放进 `home/nixos/` 基线。
 
 ## 多设备配置
 

--- a/modules/nixos/apps/ai-tools.nix
+++ b/modules/nixos/apps/ai-tools.nix
@@ -19,6 +19,7 @@ in {
     hm'.programs.codex.enable = true;
 
     hm'.home.packages = with agentPackages; [
+      chatgpt
       dsh
       zcode
     ];


### PR DESCRIPTION
## 变更说明

为已启用 `tools'.ai.enable` 的 Beelink 和 Elaina 添加 ChatGPT 桌面端，复用 `llm-agents` 中已锁定的 `chatgpt` 26.831.21537，并同步更新 `AGENTS.md` 的工具集说明。

本次仅添加软件包，保留已有 `.codex` 持久化配置。Linux 安装包中的启动代码另外将 Electron 桌面数据目录设置为 `appData/Codex`（默认 `~/.config/Codex`）；该目录不在本次持久化范围内。

## 验证方式

- [ ] 最终提交重新运行 `just check`（未重跑；添加包并包含桌面持久化条目的版本此前已通过格式、未使用声明和所有主机求值）。
- [x] `git diff --cached --check` 通过。

未执行系统构建、切换或 Linux 图形界面运行验证。

## 自查清单

- [x] 软件包沿用现有 AI 工具模块及 `tools'.ai.enable` 开关。
