### PR TITLE
feat(beelink): 启用 Firefox

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -34,6 +34,7 @@
   desktop' = {
     # Applications
     applications.enable = true;
+    apps.firefox.enable = true;
     apps.kitty.enable = true;
     apps.vscode.enable = true;
 


### PR DESCRIPTION
## 变更说明

为 Beelink 主机启用 Firefox。

## 验证方式

- [x] alejandra --check .
- [x] deadnix --fail .
- [x] nix flake check --all-systems --no-build

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
