### PR TITLE
refactor(desktop): 显式管理 MIME 默认关联

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -34,6 +34,7 @@
   desktop' = {
     # Applications
     applications.enable = true;
+    mime-apps.enable = true;
     apps.firefox.enable = true;
     apps.kitty.enable = true;
     apps.vscode.enable = true;

--- a/hosts/nixos/elaina/default.nix
+++ b/hosts/nixos/elaina/default.nix
@@ -27,6 +27,7 @@
 
   desktop' = {
     applications.enable = true;
+    mime-apps.enable = true;
     apps = {
       firefox.enable = true;
       kitty.enable = true;

--- a/modules/nixos/desktop/apps/applications.nix
+++ b/modules/nixos/desktop/apps/applications.nix
@@ -23,7 +23,6 @@ in {
       # Files and documents
       nautilus
       file-roller
-      papers
       loupe
 
       # Media
@@ -35,21 +34,6 @@ in {
     # integration for Nautilus.
     services.gvfs.enable = true;
     services.udisks2.enable = true;
-
-    hm'.xdg.mimeApps = {
-      enable = true;
-
-      # Home Manager derives all supported MIME types from the applications'
-      # desktop files. Earlier packages take precedence when MIME types overlap.
-      defaultApplicationPackages = with pkgs; [
-        file-roller
-        nautilus
-        loupe
-        papers
-        gnome-text-editor
-        mpv
-      ];
-    };
 
     preservation'.user.directories = [
       # Desktop application launchers and file manager metadata

--- a/modules/nixos/desktop/environment/mime-apps.nix
+++ b/modules/nixos/desktop/environment/mime-apps.nix
@@ -1,0 +1,104 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  browser = [
+    "firefox.desktop"
+  ];
+  editor = [
+    "code.desktop"
+    "org.gnome.TextEditor.desktop"
+  ];
+  archive = ["org.gnome.FileRoller.desktop"];
+  fileManager = ["org.gnome.Nautilus.desktop"];
+  imageViewer = ["org.gnome.Loupe.desktop"];
+  mediaPlayer = ["mpv.desktop"];
+  cfg = config.desktop'.mime-apps;
+in {
+  options.desktop'.mime-apps = {
+    enable = lib.mkEnableOption "XDG MIME application associations";
+  };
+
+  config = lib.mkIf cfg.enable {
+    hm'.home.packages = [pkgs.xdg-utils];
+
+    # Replace an existing unmanaged file so old desktop preferences cannot
+    # override the declarative defaults below.
+    hm'.xdg.configFile."mimeapps.list".force = true;
+
+    hm'.xdg.mimeApps = {
+      enable = true;
+
+      defaultApplications = {
+        # Firefox is the default browser.
+        "application/json" = browser;
+        "application/pdf" = browser;
+        "text/html" = browser;
+        "text/xml" = browser;
+        "application/xml" = browser;
+        "application/xhtml+xml" = browser;
+        "application/xhtml_xml" = browser;
+        "application/rdf+xml" = browser;
+        "application/rss+xml" = browser;
+        "application/x-extension-htm" = browser;
+        "application/x-extension-html" = browser;
+        "application/x-extension-shtml" = browser;
+        "application/x-extension-xht" = browser;
+        "application/x-extension-xhtml" = browser;
+        "x-scheme-handler/about" = browser;
+        "x-scheme-handler/ftp" = browser;
+        "x-scheme-handler/http" = browser;
+        "x-scheme-handler/https" = browser;
+
+        # VS Code is preferred for text files; GNOME Text Editor is the
+        # fallback.
+        "text/plain" = editor;
+        "application/x-zerosize" = editor;
+        "application/x-wine-extension-ini" = editor;
+
+        # VS Code uses a dedicated desktop entry for vscode:// URLs.
+        "x-scheme-handler/vscode" = ["code-url-handler.desktop"];
+
+        # These applications are installed by applications.nix. Their
+        # associations are listed explicitly so package metadata cannot
+        # silently change the user's defaults.
+        "audio/*" = mediaPlayer;
+        "video/*" = mediaPlayer;
+        "image/*" = imageViewer;
+        "image/gif" = imageViewer;
+        "image/jpeg" = imageViewer;
+        "image/png" = imageViewer;
+        "image/webp" = imageViewer;
+        "inode/directory" = fileManager;
+
+        # File Roller handles common archive formats.
+        "application/bzip2" = archive;
+        "application/gzip" = archive;
+        "application/vnd.rar" = archive;
+        "application/x-7z-compressed" = archive;
+        "application/x-7z-compressed-tar" = archive;
+        "application/x-bzip" = archive;
+        "application/x-bzip-compressed-tar" = archive;
+        "application/x-compressed-tar" = archive;
+        "application/x-cpio" = archive;
+        "application/x-gzip" = archive;
+        "application/x-rar" = archive;
+        "application/x-rar-compressed" = archive;
+        "application/x-tar" = archive;
+        "application/x-xz" = archive;
+        "application/x-xz-compressed-tar" = archive;
+        "application/x-zip" = archive;
+        "application/x-zip-compressed" = archive;
+        "application/zip" = archive;
+        "application/zstd" = archive;
+        "application/x-zstd-compressed-tar" = archive;
+      };
+
+      # Keep the association section explicit and leave unrelated desktop
+      # entries untouched.
+      associations.removed = {};
+    };
+  };
+}


### PR DESCRIPTION
## 变更说明

- 将 XDG MIME 关联拆到独立的 MIME 管理模块中，并由开关统一启用。
- 用显式 desktop entry 列表管理浏览器、编辑器、目录、图片、音视频和压缩包默认程序。
- Firefox 作为默认浏览器，VS Code 作为当前文本编辑器默认程序。
- 移除 applications.nix 中的自动 MIME 推导和未使用的 Papers。
- 在 Beelink 和 Elaina 启用 MIME 管理。

## 验证方式

- [x] alejandra --check .
- [x] deadnix --fail .
- [x] nix flake check --all-systems --no-build

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
