### PR TITLE
feat(beelink): 启用 Zed 编辑器

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -38,6 +38,7 @@
     apps.firefox.enable = true;
     apps.google-chrome.enable = true;
     apps.kitty.enable = true;
+    apps.telegram.enable = true;
     apps.vscode.enable = true;
     apps.zed.enable = true;
 

--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -39,6 +39,7 @@
     apps.google-chrome.enable = true;
     apps.kitty.enable = true;
     apps.vscode.enable = true;
+    apps.zed.enable = true;
 
     # Session and appearance
     cursors.enable = true;

--- a/modules/nixos/desktop/apps/telegram.nix
+++ b/modules/nixos/desktop/apps/telegram.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.desktop'.apps.telegram;
+in {
+  options.desktop'.apps.telegram = {
+    enable = lib.mkEnableOption "Telegram Desktop";
+  };
+
+  config = lib.mkIf cfg.enable {
+    hm'.home.packages = [pkgs.telegram-desktop];
+
+    preservation'.user.directories = [
+      # Telegram Desktop session data and settings, including tdata.
+      ".local/share/TelegramDesktop"
+    ];
+  };
+}

--- a/modules/nixos/desktop/apps/zed.nix
+++ b/modules/nixos/desktop/apps/zed.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.desktop'.apps.zed;
+in {
+  options.desktop'.apps.zed = {
+    enable = lib.mkEnableOption "Zed editor";
+  };
+
+  config = lib.mkIf cfg.enable {
+    hm'.programs.zed-editor.enable = true;
+
+    preservation'.user.directories = [
+      # Zed settings, keymaps, extensions, and language-server state.
+      {
+        directory = ".config/zed";
+        mode = "0700";
+      }
+      {
+        directory = ".local/share/zed";
+        mode = "0700";
+      }
+    ];
+  };
+}

--- a/modules/nixos/desktop/environment/mime-apps.nix
+++ b/modules/nixos/desktop/environment/mime-apps.nix
@@ -63,6 +63,9 @@ in {
         # VS Code uses a dedicated desktop entry for vscode:// URLs.
         "x-scheme-handler/vscode" = ["code-url-handler.desktop"];
 
+        # Telegram URL links use the tg:// scheme.
+        "x-scheme-handler/tg" = ["org.telegram.desktop.desktop"];
+
         # These applications are installed by applications.nix. Their
         # associations are listed explicitly so package metadata cannot
         # silently change the user's defaults.

--- a/modules/nixos/desktop/environment/mime-apps.nix
+++ b/modules/nixos/desktop/environment/mime-apps.nix
@@ -9,6 +9,7 @@
     "google-chrome.desktop"
   ];
   editor = [
+    "dev.zed.Zed.desktop"
     "code.desktop"
     "org.gnome.TextEditor.desktop"
   ];


### PR DESCRIPTION
## 变更说明

- 新增 desktop.apps.zed 开关模块，并启用 Home Manager 的 Zed 配置。
- 在 Beelink 启用 Zed 编辑器。
- 持久化 Zed 的设置、快捷键、扩展和语言服务状态。
- 将 Zed 放在文本编辑器默认列表首位，VS Code 和 GNOME Text Editor 作为后备。

## 验证方式

- [x] alejandra --check .
- [x] deadnix --fail .
- [x] nix flake check --all-systems --no-build

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
