### PR TITLE
feat(beelink): 启用 Telegram Desktop

### DIFF
--- a/hosts/nixos/beelink/default.nix
+++ b/hosts/nixos/beelink/default.nix
@@ -38,6 +38,7 @@
     apps.firefox.enable = true;
     apps.google-chrome.enable = true;
     apps.kitty.enable = true;
+    apps.telegram.enable = true;
     apps.vscode.enable = true;
     apps.zed.enable = true;
 

--- a/modules/nixos/desktop/apps/telegram.nix
+++ b/modules/nixos/desktop/apps/telegram.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.desktop'.apps.telegram;
+in {
+  options.desktop'.apps.telegram = {
+    enable = lib.mkEnableOption "Telegram Desktop";
+  };
+
+  config = lib.mkIf cfg.enable {
+    hm'.home.packages = [pkgs.telegram-desktop];
+
+    preservation'.user.directories = [
+      # Telegram Desktop session data and settings, including tdata.
+      ".local/share/TelegramDesktop"
+    ];
+  };
+}

--- a/modules/nixos/desktop/environment/mime-apps.nix
+++ b/modules/nixos/desktop/environment/mime-apps.nix
@@ -63,6 +63,9 @@ in {
         # VS Code uses a dedicated desktop entry for vscode:// URLs.
         "x-scheme-handler/vscode" = ["code-url-handler.desktop"];
 
+        # Telegram URL links use the tg:// scheme.
+        "x-scheme-handler/tg" = ["org.telegram.desktop.desktop"];
+
         # These applications are installed by applications.nix. Their
         # associations are listed explicitly so package metadata cannot
         # silently change the user's defaults.


### PR DESCRIPTION
## 变更说明

- 新增 desktop.apps.telegram 开关模块，并在 Beelink 启用 Telegram Desktop。
- 持久化 TelegramDesktop 用户数据和 tdata 会话数据。
- 将 tg:// 链接交给 Telegram Desktop。
- 不配置 tonsite scheme。

## 验证方式

- [x] alejandra --check .
- [x] deadnix --fail .
- [x] nix flake check --all-systems --no-build

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
