### PR TITLE
feat(nixos): 统一 GTK 和 Qt 的 Rosé Pine Moon 主题

### DIFF
--- a/modules/nixos/desktop/environment/themes.nix
+++ b/modules/nixos/desktop/environment/themes.nix
@@ -5,18 +5,51 @@
   ...
 }: let
   cfg = config.desktop'.themes;
+  rosePineGtkSource = pkgs.fetchzip {
+    url = "https://github.com/rose-pine/gtk/archive/3a11f84e11685aacaa749deea1e9f02872b99fdf.tar.gz";
+    hash = "sha256-58HfkFvflQhiJzfHcJCihSE9YbxbD6Koe0/aT+PVv4w=";
+  };
+  rosePineMoonGtk = pkgs.runCommand "rose-pine-moon-gtk" {} ''
+    theme="$out/share/themes/rose-pine-moon-gtk"
+    mkdir -p "$theme/gtk-4.0"
+    cp -rL ${rosePineGtkSource}/gtk3/rose-pine-moon-gtk/{gtk-3.0,gtk-3.20} "$theme/"
+    chmod -R u+w "$theme"
+    # Moon is already dark; upstream's alternate stylesheet inverts its colors.
+    for version in gtk-3.0 gtk-3.20; do
+      cp "$theme/$version/gtk.css" "$theme/$version/gtk-dark.css"
+    done
+    cp ${rosePineGtkSource}/gtk4/rose-pine-moon.css "$theme/gtk-4.0/gtk.css"
+    cp "$theme/gtk-4.0/gtk.css" "$theme/gtk-4.0/gtk-dark.css"
+  '';
 in {
   options.desktop'.themes = {
-    enable = lib.mkEnableOption "GTK and icon themes";
+    enable = lib.mkEnableOption "GTK, Qt and icon themes";
   };
 
   config = lib.mkIf cfg.enable {
+    hm'.qt = {
+      enable = true;
+      platformTheme.name = "gtk3";
+      style.name = "kvantum";
+      kvantum = {
+        enable = true;
+        settings.General.theme = "rose-pine-moon-iris";
+      };
+    };
+
+    hm'.xdg.configFile."Kvantum/rose-pine-moon-iris".source = "${pkgs.rose-pine-kvantum}/share/Kvantum/themes/rose-pine-moon-iris";
+
     hm'.gtk = {
       enable = true;
 
       theme = {
-        package = pkgs.adw-gtk3;
-        name = "adw-gtk3-dark";
+        package = rosePineMoonGtk;
+        name = "rose-pine-moon-gtk";
+      };
+
+      gtk4.theme = {
+        package = rosePineMoonGtk;
+        name = "rose-pine-moon-gtk";
       };
 
       iconTheme = {


### PR DESCRIPTION
## 变更说明

此前只配置 GTK 暗色主题，Fcitx5 等 Qt 应用仍显示默认浅色界面。本次将启用 `desktop'.themes` 的主机统一为 Rosé Pine Moon：GTK 3/4 加载 Moon 配色，Qt 5/6 使用 Kvantum 的 Moon Iris 主题，通过 GTK 平台集成共享字体和图标设置。

由于当前 Nixpkgs 已移除依赖旧 GTK 2 引擎的主题包，固定上游提交和哈希，仅打包 GTK 3/4 资源。打包时展开资源链接，并让暗色样式表使用 Moon 配色，避免上游暗色变体反色。

## 验证方式

- [x] `just check` 通过（格式、未使用声明、所有主机求值）
- [x] GTK 主题包实际构建通过，资源路径与暗色样式表检查通过
- [x] 用户应用配置后确认主题正常生效

## 自查清单

- [x] 遵循 AGENTS.md 的模块归属、命名空间和持久化约定
